### PR TITLE
Add PM2.5 measure and alarm capabilities

### DIFF
--- a/lib/deviceclasses/deviceclasses.json
+++ b/lib/deviceclasses/deviceclasses.json
@@ -872,8 +872,8 @@
 				"nl": "PM2.5 Alarm"
 			},
 			"desc": {
-				"en": "True when PM2.5 values exceeds specified values",
-				"nl": "Gaat wanneer de PM2.5 waarde overschreden wordt"
+				"en": "True when PM2.5 values exceeds threshold",
+				"nl": "Gaat af wanneer de PM2.5 waarde overschreden wordt"
 			},
 			"getable": true,
 			"setable": false

--- a/lib/deviceclasses/deviceclasses.json
+++ b/lib/deviceclasses/deviceclasses.json
@@ -88,6 +88,7 @@
 				"measure_co",
 				"measure_co2",
 				"measure_humidity",
+				"measure_pm25"
 				"measure_pressure",
 				"measure_noise",
 				"measure_rain",
@@ -111,6 +112,7 @@
 				"alarm_smoke",
 				"alarm_fire",
 				"alarm_heat",
+				"alarm_pm25"
 				"alarm_water",
 				"alarm_battery",
 				"alarm_night",
@@ -508,6 +510,24 @@
 			"getable": true,
 			"setable": false
 		},
+		"measure_pm25": {
+			"type": "number",
+			"title": {
+				"en": "PM2.5",
+				"nl": "PM2.5"
+			},
+			"units": {
+				"en": "ppm"
+			},
+			"desc": {
+				"en": "Atmospheric Particulate Matter (μg/m3)",
+				"nl": "Deeltjesvormige luchtverontreiniging (μg/m3)"
+			},
+			"chartType": "spline",
+			"decimals": 2,
+			"getable": true,
+			"setable": false
+		},
 		"measure_humidity": {
 			"type": "number",
 			"title": {
@@ -841,6 +861,19 @@
 			"desc": {
 				"en": "True when dangerous CO2 values have been detected",
 				"nl": "Gaat af bij gevaarlijke concentraties CO2"
+			},
+			"getable": true,
+			"setable": false
+		},
+		"alarm_pm25": {
+			"type": "boolean",
+			"title": {
+				"en": "PM2.5 Alarm",
+				"nl": "PM2.5 Alarm"
+			},
+			"desc": {
+				"en": "True when PM2.5 values exceeds specified values",
+				"nl": "Gaat wanneer de PM2.5 waarde overschreden wordt"
 			},
 			"getable": true,
 			"setable": false


### PR DESCRIPTION
Adding additional capabilities for the Particulate Matter (Deeltjesvormige luchtverontreiniging) capabilities for both measure as well as alarm.

For the icons, I took the liberty to re-use the CO2 clouds (mirrored) and add some particles to it...
See attached ZIP:
[icons_pm25.zip](https://github.com/athombv/node-homey-lib/files/1258064/icons_pm25.zip)

A bit bigger then 2.5 um though ;-P