### PR TITLE
Add relevant capabilities to Lock device class

### DIFF
--- a/lib/deviceclasses/deviceclasses.json
+++ b/lib/deviceclasses/deviceclasses.json
@@ -196,7 +196,12 @@
 			"capabilities": [
 				"locked",
 				"lock_mode",
-				"measure_battery"
+				"measure_battery",
+				"alarm_generic",
+				"alarm_contact",
+				"alarm_tamper",
+				"alarm_heat",
+				"alarm_battery"
 			]
 		},
 		"windowcoverings": {


### PR DESCRIPTION
Following request on Slack in Developers channel.

Request to additional the following capabilities relevant for the lock device class:
"alarm_generic",
"alarm_contact",
"alarm_tamper",
"alarm_heat",
"alarm_battery"

Reference device using these capabilities: https://github.com/TedTolboom/no.IDLock/blob/development/alarm_contact/config/drivers/IDlock101.json

Also others use similar capabilities.