### PR TITLE
Improve logging

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -207,7 +207,7 @@ class App {
                             if (size === 1 && max > 127 && max < 255 && signed ||
                                 size === 2 && max > 32767 && max < 65535 && signed ||
                                 size === 4 && max > 2147483647 && max < 4294967295 && signed)
-                            		throw new Error(`Value cannot be signed: ${driver}, ${setting}`);
+                            		throw new Error(`Value cannot be signed: ${driver.id}, ${setting.id}`);
 						}
                     }
                 }


### PR DESCRIPTION
Prevent logging `[Object object]` which is not really helpful when debugging settings' signed values.