### PR TITLE
Check if array before looping

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -190,7 +190,7 @@ class App {
 					}
 				}
 
-                if (driver.zwave) {
+                if (driver.zwave && Array.isArray(driver.settings)) {
                     for (let j = 0; j < driver.settings.length; j++) {
                         let setting = driver.settings[j];
                         if (setting.zwave && setting.attr && setting.attr.max) {


### PR DESCRIPTION
This bug resulted in a very nice verbose error:
```
✓ Validating app...
✘ Homey App did not validate against level `debug`:
Cannot read property 'length' of undefined
Not installing, please fix the validation issues first
```