### PR TITLE
added cmds to mandatory_fields

### DIFF
--- a/lib/Signal/index.js
+++ b/lib/Signal/index.js
@@ -71,7 +71,7 @@ class Signal {
 	}
 	
 	_validateRegular() {
-		this._check( 'mandatory_fields', this._signal.hasOwnProperty('sof') || this._signal.hasOwnProperty('eof') || this._signal.hasOwnProperty('words') );
+		this._check( 'mandatory_fields', this._signal.hasOwnProperty('sof') || this._signal.hasOwnProperty('eof') || this._signal.hasOwnProperty('words') || this._signal.hasOwnProperty('cmds'));
 		this._validateWithEngine( genericValidator );
 		this._validateWithEngine( rfValidator );
 		


### PR DESCRIPTION
This is related to the issue #112.
I didn't really know how to test this change, but I think it might do the trick: It should allow users to configure commands without being restricted to the prontohex format.