### PR TITLE
Make sure node_modules/ doesn't contain symlinks when validating for publication

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -13,6 +13,7 @@ const Signal = require('../Signal');
 const statAsync = util.promisify( fs.stat );
 const readFileAsync = util.promisify( fs.readFile );
 const readDirAsync = util.promisify( fs.readdir );
+const lstatAsync = util.promisify( fs.lstat );
 const imageSizeAsync = util.promisify( imageSize );
 
 const VALIDATION_LEVELS = [
@@ -395,10 +396,10 @@ class App {
 
 	async _validateModules(dir) {
 		// Make sure there are no symlinked (`npm link`) modules left in `node_modules`.
-		for (let file of fs.readdirSync(dir)) {
+		for (let file of await readDirAsync(dir)) {
 			let stat;
 			try {
-				stat = fs.lstatSync(path.join(dir, file));
+				stat = await lstatAsync(path.join(dir, file));
 			} catch(e) {
 				throw Error(`Invalid module '${ file }' in 'node_modules': ` + e.message);
 			}

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -303,6 +303,7 @@ class App {
 		
 		if( levelPublish ) {
 			await this._validateImages(appJson.images, 'app');
+			await this._validateModules(path.join('node_modules'));
 		}
 		
 		this.debug(`Validated successfully`);
@@ -389,6 +390,21 @@ class App {
 			if( imageSize.width !== requiredSize.width
 			 || imageSize.height !== requiredSize.height )
 			 	throw new Error(`Invalid image size (${imageSize.width}x${imageSize.height}): ${imagePath}\nRequired: ${requiredSize.width}x${requiredSize.height}`);
+		}
+	}
+
+	async _validateModules(dir) {
+		// Make sure there are no symlinked (`npm link`) modules left in `node_modules`.
+		for (let file of fs.readdirSync(dir)) {
+			let stat;
+			try {
+				stat = fs.lstatSync(path.join(dir, file));
+			} catch(e) {
+				throw Error(`Invalid module '${ file }' in 'node_modules': ` + e.message);
+			}
+			if (stat.isSymbolicLink()) {
+				throw Error(`Invalid module '${ file }' in 'node_modules': is a symbolic link`);
+			}
 		}
 	}
 	


### PR DESCRIPTION
I was able to publish an app that had a dangling symbolic link in `node_modules/` (left there because during development I used `npm link module`).

This PR adds an additional validation step, for "publish" validation only, to make sure there are no symlinks in `node_modules`.