### PR TITLE
Add A23 battery

### DIFF
--- a/lib/Energy/index.js
+++ b/lib/Energy/index.js
@@ -11,6 +11,7 @@ class Energy {
       'LS14250',
       'AA',
       'AAA',
+      'A23',
       'A27',
       'PP3',
       'CR123A',


### PR DESCRIPTION
Used in KaKu, Action, Elro, Flamingo etc devices.