### PR TITLE
Turn errors into readable text

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -87,10 +87,10 @@ class App {
       schema.properties.drivers.items.required = schema.properties.drivers.items.required.concat( schema.properties.drivers.items.requiredPublish );
     }
 
-    const ajv = new Ajv({ async: true });
+    const ajv = new Ajv({ async: true, allErrors: true });
     const validate = ajv.compile( schema );
     const valid = await validate( appJson );
-    if( valid === false ) throw new Error( ajv.errorsText(validate.errors, { dataVar: 'manifest' }) || 'Invalid App JSON' );
+    if( valid === false ) throw new Error( ajv.errorsText(validate.errors, { dataVar: 'manifest', separator: '\n' }) || 'Invalid app.json' );
 
     // validate `appJson.id`
     if( !App.isValidId(appJson.id) )

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -90,7 +90,7 @@ class App {
     const ajv = new Ajv({ async: true, allErrors: true });
     const validate = ajv.compile( schema );
     const valid = await validate( appJson );
-    if( valid === false ) throw new Error( ajv.errorsText(validate.errors, { dataVar: 'manifest', separator: '\n' }) || 'Invalid app.json' );
+    if( valid === false ) throw new Error( this.constructor.errorsText(validate.errors) || 'Invalid app.json' );
 
     // validate `appJson.id`
     if( !App.isValidId(appJson.id) )
@@ -618,6 +618,24 @@ class App {
     } while( !brandColor );
     
     return brandColor;
+  }
+
+  static errorsText(errors) {
+    if (Array.isArray(errors) === false) return;
+
+    return errors.reduce((message, error) => {
+      let info = '';
+      switch (error.keyword) {
+        case 'oneOf':
+          return message + `manifest${error.dataPath} matched no available schemas, see previous errors\n`;
+
+        case 'enum':
+          info = JSON.stringify(error.params.allowedValues);
+          break;
+      }
+
+      return message + `manifest${error.dataPath} ${error.message} ${info}\n`;
+    }, '').slice(0, -1); // remove final '\n' character
   }
 
 }

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -87,10 +87,10 @@ class App {
       schema.properties.drivers.items.required = schema.properties.drivers.items.required.concat( schema.properties.drivers.items.requiredPublish );
     }
 
-    const avj = new Ajv({ async: true });
-    const validate = avj.compile( schema );
+    const ajv = new Ajv({ async: true });
+    const validate = ajv.compile( schema );
     const valid = await validate( appJson );
-    if( valid === false ) throw new Error( JSON.stringify(validate.errors, false, 4) || 'Invalid App JSON' );
+    if( valid === false ) throw new Error( ajv.errorsText(validate.errors, { dataVar: 'manifest' }) || 'Invalid App JSON' );
 
     // validate `appJson.id`
     if( !App.isValidId(appJson.id) )


### PR DESCRIPTION
from 

```
✖ Homey App did not validate against level `debug`:
[
    {
        "keyword": "maximum",
        "dataPath": ".sdk",
        "schemaPath": "#/properties/sdk/maximum",
        "params": {
            "comparison": "<=",
            "limit": 2,
            "exclusive": false
        },
        "message": "should be <= 2"
    }
]
Not installing, please fix the validation issues first
```

to

```
✖ Homey App did not validate against level `debug`:
manifest.sdk should be <= 2
Not installing, please fix the validation issues first
```