### PR TITLE
feat: validate compatibility for sdk v3 apps

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -110,6 +110,17 @@ class App {
       throw new Error('Invalid compatibility');
     }
 
+    // validate sdk v3 apps have compatibility of at least >=5.0.0
+    if (appJson.sdk === 3) {
+      // lowest version that satisfies the compatibility
+      const minVersion = semver.minVersion(appJson.compatibility);
+
+      // lowest version must be greater than or equal to 5.0.0 for sdk v3 apps
+      if (!semver.gte(minVersion, '5.0.0')) {
+        throw new Error(`Invalid compatibility (${appJson.compatibility}), SDK version 3 apps must have a compatibility of at least >=5.0.0`);
+      }
+    }
+
     // validate `appJson.permissions`
     if( Array.isArray(appJson.permissions) ) {
 
@@ -166,7 +177,7 @@ class App {
 
           if( !isSystemCapability && !isAppCapability )
             throw new Error(`Invalid capability: ${capability}`)
-            
+
             // validate battery
           if( BATTERY_CAPABILITIES.includes(capabilityId) ) {
             if( !driver.energy || !Array.isArray(driver.energy.batteries) )
@@ -233,13 +244,13 @@ class App {
         if( levelPublish ) {
           await this._validateImages(driver.images, 'driver');
         }
-        
+
         // validate `appJson.drivers[].discovery`
         if( typeof driver.discovery === 'string' ) {
           if( !appJson.discovery || !appJson.discovery[driver.discovery] )
             throw new Error(`Invalid driver discovery: ${driver.discovery}`);
         }
-        
+
         if( typeof driver.energy === 'object' ) {
           if( Array.isArray(driver.energy.batteries) ) {
             const allowedBatteries = Energy.getBatteries();
@@ -296,8 +307,8 @@ class App {
         }
       }
     }
-    
-    
+
+
     // validate `appJson.discovery`
     if( appJson.discovery ) {
       for( const discoveryId in appJson.discovery ) {
@@ -520,7 +531,7 @@ class App {
         const argsMatches = findStringBetween(titleFormatted, '\\[\\[', '\\]\\]');
         if(!Array.isArray(argsMatches))
             throw Error(`Missing all args in ${errorPath}`);
-        
+
         argsMatches.forEach(argMatch => {
           const argName = argMatch.substring(2, argMatch.length-2);
           if( typeof args[argName] === 'undefined' )
@@ -596,12 +607,12 @@ class App {
   static getLocales() {
     return [ 'ab', 'aa', 'af', 'ak', 'sq', 'am', 'ar', 'an', 'hy', 'as', 'av', 'ae', 'ay', 'az', 'bm', 'ba', 'eu', 'be', 'bn', 'bh', 'bi', 'bs', 'br', 'bg', 'my', 'ca', 'ch', 'ce', 'ny', 'zh', 'cv', 'kw', 'co', 'cr', 'hr', 'cs', 'da', 'dv', 'nl', 'dz', 'en', 'eo', 'et', 'ee', 'fo', 'fj', 'fi', 'fr', 'ff', 'gl', 'ka', 'de', 'el', 'gn', 'gu', 'ht', 'ha', 'he', 'hz', 'hi', 'ho', 'hu', 'ia', 'id', 'ie', 'ga', 'ig', 'ik', 'io', 'is', 'it', 'iu', 'ja', 'jv', 'kl', 'kn', 'kr', 'ks', 'kk', 'km', 'ki', 'rw', 'ky', 'kv', 'kg', 'ko', 'ku', 'kj', 'la', 'lb', 'lg', 'li', 'ln', 'lo', 'lt', 'lu', 'lv', 'gv', 'mk', 'mg', 'ms', 'ml', 'mt', 'mi', 'mr', 'mh', 'mn', 'na', 'nv', 'nd', 'ne', 'ng', 'nb', 'nn', 'no', 'ii', 'nr', 'oc', 'oj', 'cu', 'om', 'or', 'os', 'pa', 'pi', 'fa', 'pl', 'ps', 'pt', 'qu', 'rm', 'rn', 'ro', 'ru', 'sa', 'sc', 'sd', 'se', 'sm', 'sg', 'sr', 'gd', 'sn', 'si', 'sk', 'sl', 'so', 'st', 'es', 'su', 'sw', 'ss', 'sv', 'ta', 'te', 'tg', 'th', 'ti', 'bo', 'tk', 'tl', 'tn', 'to', 'tr', 'ts', 'tt', 'tw', 'ty', 'ug', 'uk', 'ur', 'uz', 've', 'vi', 'vo', 'wa', 'cy', 'wo', 'fy', 'xh', 'yi', 'yo', 'za', 'zu' ];
   }
-  
+
   static getBrandColor(appId) {
     const appIdHex = Buffer.from(appId).toString('hex');
     let brandColor;
     let i = 0;
-    
+
     do {
       const hexString = `${appIdHex}${++i}`;
       let color = tinycolor('#' + hexString.substring(hexString.length-6));
@@ -616,7 +627,7 @@ class App {
         brandColor = hex;
       }
     } while( !brandColor );
-    
+
     return brandColor;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3231,9 +3231,9 @@
       }
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "serialize-javascript": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "ajv": "^6.1.1",
     "image-size": "^0.6.2",
-    "semver": "^5.5.0",
+    "semver": "^5.7.0",
     "tinycolor2": "^1.4.1"
   },
   "config": {


### PR DESCRIPTION
This bumps the semver dependency from ^5.5.0 to ^5.7.0, as of 5.7.0 `semver.minVersion()` is available.