### PR TITLE
feat: add C type batteries

### DIFF
--- a/lib/Energy/index.js
+++ b/lib/Energy/index.js
@@ -9,6 +9,7 @@ class Energy {
   static getBatteries() {
      return [
       'LS14250',
+      'C',
       'AA',
       'AAA',
       'A23',


### PR DESCRIPTION
This PR adds the `C` type batteries: https://en.wikipedia.org/wiki/List_of_battery_sizes#Cylindrical_batteries as requested here: https://github.com/athombv/homey-apps-sdk-issues/issues/142
