### PR TITLE
fix: enable garagedoor deviceclass

### DIFF
--- a/assets/capability/capabilities.json
+++ b/assets/capability/capabilities.json
@@ -53,6 +53,7 @@
   "channel_down",
   "locked",
   "lock_mode",
+  "garagedoor_closed",
   "windowcoverings_state",
   "windowcoverings_tilt_up",
   "windowcoverings_tilt_down",

--- a/assets/capability/capabilities/garagedoor_closed.json
+++ b/assets/capability/capabilities/garagedoor_closed.json
@@ -1,0 +1,109 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "Closed",
+    "nl": "Gesloten",
+    "de": "Geschlossen",
+    "fr": "Fermé",
+    "it": "Chiuse",
+    "sv": "Stängd",
+    "no": "Lukket",
+    "es": "Cerrados",
+    "da": "Lukket"
+  },
+  "getable": true,
+  "setable": true,
+  "uiComponent": "toggle",
+  "$flow": {
+    "triggers": [
+      {
+        "id": "garagedoor_closed_true",
+        "title": {
+          "en": "Closed",
+          "nl": "Gesloten",
+          "de": "Geschlossen",
+          "fr": "Fermé",
+          "it": "Chiuse",
+          "sv": "Stängd",
+          "no": "Lukket",
+          "es": "Cerrados",
+          "da": "Lukket"
+        }
+      },
+      {
+        "id": "garagedoor_closed_false",
+        "title": {
+          "en": "Opened",
+          "nl": "Geopend",
+          "de": "Offen",
+          "fr": "Ouvert",
+          "it": "Aperte",
+          "sv": "Öppen",
+          "no": "Åpen",
+          "es": "Abiertos",
+          "da": "Åben"
+        }
+      }
+    ],
+    "conditions": [
+      {
+        "id": "closed",
+        "title": {
+          "en": "Is !{{closed|open}}",
+          "nl": "Is !{{gesloten|geopend}}",
+          "de": "Ist !{{geschlossen|offen}}",
+          "fr": "Est !{{fermé|ouvert}}",
+          "it": "È !{{chiuso|aperto}}",
+          "sv": "Är !{{stängd|öppen}}",
+          "no": "Er !{{lukket|åpen}}",
+          "es": "Está !{{cerrado|abierto}}",
+          "da": "Er !{{lukket|åben}}"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "id": "close",
+        "title": {
+          "en": "Close",
+          "nl": "Sluiten",
+          "de": "Schließen",
+          "fr": "Fermer",
+          "it": "Chiudi",
+          "sv": "Stäng",
+          "no": "Lukk",
+          "es": "Cerrar",
+          "da": "Luk"
+        }
+      },
+      {
+        "id": "open",
+        "title": {
+          "en": "Open",
+          "nl": "Openen",
+          "de": "Öffnen",
+          "fr": "Ouvrir",
+          "it": "Apri",
+          "sv": "Öppna",
+          "no": "Åpne",
+          "es": "Abrir",
+          "da": "Åbn"
+        }
+      },
+      {
+        "id": "toggle",
+        "title": {
+          "en": "Toggle open or closed",
+          "nl": "Schakel tussen geopend en gesloten",
+          "de": "Offen/Geschlossen umschalten",
+          "fr": "Alterner ouvert/fermé",
+          "it": "Alterna aperte/chiuse",
+          "sv": "Växla mellan öppen eller stängd",
+          "no": "Veksle mellom åpen og lukket",
+          "es": "Abrir o cerrar",
+          "da": "Skift mellem åben og lukket"
+        }
+      }
+    ]
+  }
+}

--- a/assets/capability/capabilities/onoff.json
+++ b/assets/capability/capabilities/onoff.json
@@ -126,7 +126,7 @@
           "da": "Er !{{åben|lukket}}"    
         },
         "$filter": {
-          "class": "windowcoverings|curtain|blinds|sunshade|garagedoor"
+          "class": "windowcoverings|curtain|blinds|sunshade"
         }
       }
     ],
@@ -204,40 +204,6 @@
         },
         "$filter": {
           "class": "windowcoverings|curtain|blinds|sunshade"
-        }
-      },
-      {
-        "id": "open",
-        "title": {
-          "en": "Open garagedoor",
-          "nl": "Open de garagedeur",
-          "de": "Garagentor öffnen",
-          "fr": "Ouvrir porte de garage",
-          "it": "Apri le porta del garage",
-          "sv": "Öppna garagedörr",
-          "no": "Åpne garasjedør",
-          "es": "Abrir puerta de garaje",
-          "da": "Åbn garageport"
-        },
-        "$filter": {
-          "class": "garagedoor"
-        }
-      },
-      {
-        "id": "close",
-        "title": {
-          "en": "Close garagedoor",
-          "nl": "Sluit de garagedeur",
-          "de": "Garagentor schließen",
-          "fr": "Fermer porte de garage",
-          "it": "Chiudi le porta del garage",
-          "sv": "Stäng garagedörr",
-          "no": "Lukk garasjedør",
-          "es": "Cerrar puerta de garaje",
-          "da": "Luk garageport"
-        },
-        "$filter": {
-          "class": "garagedoor"
         }
       }
     ]

--- a/assets/capability/capabilities/onoff.json
+++ b/assets/capability/capabilities/onoff.json
@@ -126,7 +126,7 @@
           "da": "Er !{{åben|lukket}}"    
         },
         "$filter": {
-          "class": "windowcoverings|curtain|blinds|sunshade"
+          "class": "windowcoverings|curtain|blinds|sunshade|garagedoor"
         }
       }
     ],
@@ -204,6 +204,40 @@
         },
         "$filter": {
           "class": "windowcoverings|curtain|blinds|sunshade"
+        }
+      },
+      {
+        "id": "open",
+        "title": {
+          "en": "Open garagedoor",
+          "nl": "Open de garagedeur",
+          "de": "Garagentor öffnen",
+          "fr": "Ouvrir porte de garage",
+          "it": "Apri le porta del garage",
+          "sv": "Öppna garagedörr",
+          "no": "Åpne garasjedør",
+          "es": "Abrir puerta de garaje",
+          "da": "Åbn garageport"
+        },
+        "$filter": {
+          "class": "garagedoor"
+        }
+      },
+      {
+        "id": "close",
+        "title": {
+          "en": "Close garagedoor",
+          "nl": "Sluit de garagedeur",
+          "de": "Garagentor schließen",
+          "fr": "Fermer porte de garage",
+          "it": "Chiudi le porta del garage",
+          "sv": "Stäng garagedörr",
+          "no": "Lukk garasjedør",
+          "es": "Cerrar puerta de garaje",
+          "da": "Luk garageport"
+        },
+        "$filter": {
+          "class": "garagedoor"
         }
       }
     ]

--- a/assets/device/classes.json
+++ b/assets/device/classes.json
@@ -7,6 +7,7 @@
   "curtain",
   "doorbell",
   "fan",
+  "garagedoor",
   "heater",
   "homealarm",
   "kettle",


### PR DESCRIPTION
Related issue: https://github.com/athombv/homey-apps-sdk-issues/issues/95

Took me awhile to get around to this one, turns out garagedoor was already defined, just not listed in the `classes.json` file. I also added it to the `onoff` capability so it has open / close actions.

Note that there is another device class that isn't listed: `relay`. I'm not sure whether we want to add that or not.