### PR TITLE
Add options to disable zoneactivity

### DIFF
--- a/assets/capability/capabilities/alarm_contact.json
+++ b/assets/capability/capabilities/alarm_contact.json
@@ -49,7 +49,7 @@
   "setable": false,
   "uiComponent": "sensor",
   "options": {
-    "zoneActivity": "boolean"
+    "zoneActivity": true
   },
   "$flow": {
     "triggers": [

--- a/assets/capability/capabilities/alarm_contact.json
+++ b/assets/capability/capabilities/alarm_contact.json
@@ -48,6 +48,9 @@
   "getable": true,
   "setable": false,
   "uiComponent": "sensor",
+  "options": {
+    "zoneActivity": "boolean"
+  },
   "$flow": {
     "triggers": [
       {

--- a/assets/capability/capabilities/alarm_motion.json
+++ b/assets/capability/capabilities/alarm_motion.json
@@ -38,7 +38,7 @@
   "setable": false,
   "uiComponent": "sensor",
   "options": {
-    "zoneActivity": "boolean"
+    "zoneActivity": true
   },
   "$flow": {
     "triggers": [

--- a/assets/capability/capabilities/alarm_motion.json
+++ b/assets/capability/capabilities/alarm_motion.json
@@ -37,6 +37,9 @@
   "getable": true,
   "setable": false,
   "uiComponent": "sensor",
+  "options": {
+    "zoneActivity": "boolean"
+  },
   "$flow": {
     "triggers": [
       {


### PR DESCRIPTION
As far as I understand this is the place to indicate which kind of capabilitiesOptions there are. 

The 'zoneActivity' property is added for `alarm_contact` and `alarm_motion`. 