### PR TITLE
feat: add optional image size x-large

### DIFF
--- a/assets/app/schema.json
+++ b/assets/app/schema.json
@@ -47,15 +47,18 @@
 			}
 		},
 		"images": {
-			"required": [ "large", "small" ],
-			"additionalProperties": false,
+      "required": [ "large", "small" ],
+      "additionalProperties": false,
 			"properties": {
 				"large": {
 					"type": "string"
 				},
 				"small": {
 					"type": "string"
-				}
+        },
+        "x-large": {
+          "type": "string"
+        }
 			}
 		},
 		"flowCard": {

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -37,10 +37,12 @@ const IMAGE_SIZES = {
   'app': {
     'small': { width: 250, height: 175 },
     'large': { width: 500, height: 350 },
+    'x-large': { width: 1000, height: 700 },
   },
   'driver': {
     'small': { width: 75, height: 75 },
     'large': { width: 500, height: 500 },
+    'x-large': { width: 1000, height: 1000 },
   }
 }
 const BATTERY_CAPABILITIES = [


### PR DESCRIPTION
~~Had to disable `additionalProperties: false` for the images schema. Would be better if we could only allow the optional "x-large" property, but could not find a way to do that with AJV (please correct me if I'm wrong).~~