### PR TITLE
feat: fail app validation on permission com.athom.homeyscript

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -129,6 +129,12 @@ class App {
       let allowedPermissions = App.getPermissions();
 
       appJson.permissions.forEach(permission => {
+
+
+        if (permission === 'homey:app:com.athom.homeyscript') {
+          throw new Error(`Forbidden permission: ${permission}`)
+        }
+
         if( permission.indexOf('homey:app:') === 0 ) return;
         if( typeof allowedPermissions[permission] === 'undefined' )
           throw new Error(`Invalid permission: ${permission}`)


### PR DESCRIPTION
This pr adds a validation step to error on permission `com.athom.homeyscript` which is not allowed.