### PR TITLE
fix: title formatted warning

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -513,9 +513,6 @@ class App {
         return obj;
       }, {});
 
-      if( card.droptoken )
-        argsPresent.droptoken = false;
-
       // Match any characters between `[[` and `]]`
       const argsMatches = titleFormatted.match(/\[\[(.*?)\]\]/gm);
       if(argsMatches === null)
@@ -553,6 +550,10 @@ class App {
     });
 
     if (filteredCardArgs.length === 0) return;
+
+    if (card.droptoken) {
+      filteredCardArgs.push({ name: 'droptoken' });
+    }
 
     if( typeof card.titleFormatted === 'undefined' ) {
       console.warn(`Warning: ${errorPath}.titleFormatted is missing. Specifying a Flow card's formatted title will be required in the future.`);

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -507,23 +507,7 @@ class App {
   _validateFlowCard(card, errorPath) {
     if (Array.isArray(card.args) === false) return;
 
-    const checkTitleFormatted = (titleFormatted, errorPath) => {
-
-      let foundFirstDevice = false;
-
-      // Filter to valid arguments for flow card titles
-      const args = card.args.filter(arg => {
-        if( foundFirstDevice ) return true;
-        if(arg.type !== 'device') return true;
-        if(!arg.filter) return true;
-        const query = querystring.parse(arg.filter);
-        if(!query.driver_id && !query.driverId) return true;
-        foundFirstDevice = true;
-        return false;
-      });
-
-      if (args.length === 0) return;
-
+    const checkTitleFormatted = (titleFormatted, args, errorPath) => {
       const argsPresent = args.reduce((obj, arg) => {
         obj[arg.name] = false;
         return obj;
@@ -555,18 +539,33 @@ class App {
       }
     };
 
+    let foundFirstDevice = false;
+
+    // Filter to valid arguments for flow card titles
+    const filteredCardArgs = card.args.filter(arg => {
+      if( foundFirstDevice ) return true;
+      if(arg.type !== 'device') return true;
+      if(!arg.filter) return true;
+      const query = querystring.parse(arg.filter);
+      if(!query.driver_id && !query.driverId) return true;
+      foundFirstDevice = true;
+      return false;
+    });
+
+    if (filteredCardArgs.length === 0) return;
+
     if( typeof card.titleFormatted === 'undefined' ) {
       console.warn(`Warning: ${errorPath}.titleFormatted is missing. Specifying a Flow card's formatted title will be required in the future.`);
     }
 
     if( typeof card.titleFormatted === 'string' ) {
-      checkTitleFormatted(card.titleFormatted, `${errorPath}.titleFormatted`);
+      checkTitleFormatted(card.titleFormatted, filteredCardArgs, `${errorPath}.titleFormatted`);
       return;
     }
 
     if (typeof card.titleFormatted === 'object' && card.titleFormatted !== null) {
       for (const [language, titleFormatted] of Object.entries(card.titleFormatted)) {
-        checkTitleFormatted(titleFormatted, `${errorPath}.titleFormatted.${language}`);
+        checkTitleFormatted(titleFormatted, filteredCardArgs, `${errorPath}.titleFormatted.${language}`);
       }
       return;
     }

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -507,35 +507,6 @@ class App {
   _validateFlowCard(card, errorPath) {
     if (Array.isArray(card.args) === false) return;
 
-    const checkTitleFormatted = (titleFormatted, args, errorPath) => {
-      const argsPresent = args.reduce((obj, arg) => {
-        obj[arg.name] = false;
-        return obj;
-      }, {});
-
-      // Match any characters between `[[` and `]]`
-      const argsMatches = titleFormatted.match(/\[\[(.*?)\]\]/gm);
-      if(argsMatches === null)
-          throw Error(`Missing all args in ${errorPath}`);
-
-      argsMatches.forEach(argMatch => {
-        const argName = argMatch.substring(2, argMatch.length-2);
-        if( typeof argsPresent[argName] === 'undefined' )
-          throw Error(`Invalid [[${argName}]] in ${errorPath}.titleFormatted`);
-
-        if( argsPresent[argName] === true )
-          throw Error(`Duplicate [[${argName}]] in ${errorPath}.titleFormatted`);
-
-        if( argsPresent[argName] === false )
-        argsPresent[argName] = true;
-      });
-
-      for( const [argName, isPresent] of Object.entries(argsPresent) ) {
-        if( isPresent === false )
-          throw Error(`Missing [[${argName}]] in ${errorPath}`);
-      }
-    };
-
     let foundFirstDevice = false;
 
     // Filter to valid arguments for flow card titles
@@ -560,17 +531,46 @@ class App {
     }
 
     if( typeof card.titleFormatted === 'string' ) {
-      checkTitleFormatted(card.titleFormatted, filteredCardArgs, `${errorPath}.titleFormatted`);
+      App._checkTitleFormatted(card.titleFormatted, filteredCardArgs, `${errorPath}.titleFormatted`);
       return;
     }
 
     if (typeof card.titleFormatted === 'object' && card.titleFormatted !== null) {
       for (const [language, titleFormatted] of Object.entries(card.titleFormatted)) {
-        checkTitleFormatted(titleFormatted, filteredCardArgs, `${errorPath}.titleFormatted.${language}`);
+        App._checkTitleFormatted(titleFormatted, filteredCardArgs, `${errorPath}.titleFormatted.${language}`);
       }
       return;
     }
   }
+
+  static _checkTitleFormatted(titleFormatted, args, errorPath) {
+    const argsPresent = args.reduce((obj, arg) => {
+      obj[arg.name] = false;
+      return obj;
+    }, {});
+
+    // Match any characters between `[[` and `]]`
+    const argsMatches = titleFormatted.match(/\[\[(.*?)\]\]/gm);
+    if(argsMatches === null)
+        throw Error(`Missing all args in ${errorPath}`);
+
+    argsMatches.forEach(argMatch => {
+      const argName = argMatch.substring(2, argMatch.length-2);
+      if( typeof argsPresent[argName] === 'undefined' )
+        throw Error(`Invalid [[${argName}]] in ${errorPath}.titleFormatted`);
+
+      if( argsPresent[argName] === true )
+        throw Error(`Duplicate [[${argName}]] in ${errorPath}.titleFormatted`);
+
+      if( argsPresent[argName] === false )
+      argsPresent[argName] = true;
+    });
+
+    for( const [argName, isPresent] of Object.entries(argsPresent) ) {
+      if( isPresent === false )
+        throw Error(`Missing [[${argName}]] in ${errorPath}`);
+    }
+  };
 
   async _readBytes( filepath, numBytes ) {
     filepath = join( this._path, filepath );


### PR DESCRIPTION
homey-lib warns about a missing titleFormatted for the following flow, however the device argument is not a real argument so the only solution is to have a titleFormatted without arguments (same as the title).

```json
{
  "title": {
    "en": "Test title"
  },
  "args": [
    {
      "type": "device",
      "name": "device",
      "filter": "driver_id=test_driver"
    }
  ]
}
```

In this PR we check the filtered arguments earlier and we bail out before the warning if we find no arguments that need to be in titleFormatted.

I did notice that `droptoken` is optional in titleFormatted, do we want to make this argument also required?

First commit contains the actual fix.

I'm not sure if this is what we want though, do we want to make titleFormatted required for all flow cards or only for those with arguments?