### PR TITLE
feat: speaker_playing triggers

### DIFF
--- a/assets/capability/capabilities/speaker_playing.json
+++ b/assets/capability/capabilities/speaker_playing.json
@@ -16,6 +16,36 @@
   "uiComponent": "media",
   "uiQuickAction": true,
   "$flow": {
+    "triggers": [
+      {
+        "id": "speaker_playing_true",
+        "title": {
+          "en": "Started playing",
+          "nl": "Begint af te spelen",
+          "de": "Begann zu spielen",
+          "fr": "",
+          "it": "",
+          "sv": "",
+          "no": "",
+          "es": "",
+          "da": ""
+        }
+      },
+      {
+        "id": "speaker_playing_false",
+        "title": {
+          "en": "Stopped playing",
+          "nl": "Gestopt met afspelen",
+          "de": "Hörte auf zu spielen",
+          "fr": "",
+          "it": "",
+          "sv": "",
+          "no": "",
+          "es": "",
+          "da": ""
+        }
+      }
+    ],
     "conditions": [
       {
         "id": "is_playing",

--- a/assets/capability/capabilities/speaker_playing.json
+++ b/assets/capability/capabilities/speaker_playing.json
@@ -22,7 +22,13 @@
         "title": {
           "en": "Started playing",
           "nl": "Begint af te spelen",
-          "de": "Begann zu spielen"
+          "de": "Begann zu spielen",
+          "fr": "Lecture démarrée",
+          "it": "Riproduzione avviata",
+          "sv": "Började spela",
+          "no": "Startet spilling",
+          "es": "Reproducción iniciada",
+          "da": "Begyndte at spille"
         }
       },
       {
@@ -30,7 +36,13 @@
         "title": {
           "en": "Stopped playing",
           "nl": "Gestopt met afspelen",
-          "de": "Hörte auf zu spielen"
+          "de": "Hörte auf zu spielen",
+          "fr": "Lecture stoppée",
+          "it": "Riproduzione interrotta",
+          "sv": "Slutade spela",
+          "no": "Stanset spilling",
+          "es": "Reproducción detenida",
+          "da": "Stoppede med at spille"
         }
       }
     ],

--- a/assets/capability/capabilities/speaker_playing.json
+++ b/assets/capability/capabilities/speaker_playing.json
@@ -22,13 +22,7 @@
         "title": {
           "en": "Started playing",
           "nl": "Begint af te spelen",
-          "de": "Begann zu spielen",
-          "fr": "",
-          "it": "",
-          "sv": "",
-          "no": "",
-          "es": "",
-          "da": ""
+          "de": "Begann zu spielen"
         }
       },
       {
@@ -36,13 +30,7 @@
         "title": {
           "en": "Stopped playing",
           "nl": "Gestopt met afspelen",
-          "de": "Hörte auf zu spielen",
-          "fr": "",
-          "it": "",
-          "sv": "",
-          "no": "",
-          "es": "",
-          "da": ""
+          "de": "Hörte auf zu spielen"
         }
       }
     ],


### PR DESCRIPTION
fixes: https://github.com/athombv/homey-apps-sdk-issues/issues/199

Is it "stopped playing" or "was paused"?
I'm not sure how we get the other translations.

For many devices this status is not synced back to Homey so there are going to be cases where these Flow cards don't work... Maybe this is actually not such a good idea to add for all devices with `speaker_playing`?