### PR TITLE
Increase no of digits on water meter to 3 to show litres on plate

### DIFF
--- a/assets/capability/capabilities/meter_water.json
+++ b/assets/capability/capabilities/meter_water.json
@@ -11,7 +11,7 @@
     "es": "Contador de agua",
     "da": "Vandmåler"  
   },
-  "decimals": 2,
+  "decimals": 3,
   "min": 0,
   "units": {
     "en": "m³"


### PR DESCRIPTION
No of digits currently shown on Water Meter is only 2 , while the measurement from the device is in liters (3 digits).
So, if the proximity sensor 'sees' a signal, 1 liter was consumed, with 3 digits , this would be visible.

Caveat: not sure if in the past no of digits was lowered because maybe it did not fit for large numbers?