### PR TITLE
fix: require either getable or setable

### DIFF
--- a/assets/capability/schema.json
+++ b/assets/capability/schema.json
@@ -22,6 +22,10 @@
 		}
 	},
 	"required": [ "title", "type" ],
+	"anyOf": [
+		{ "required": [ "getable" ] },
+		{ "required": [ "setable" ] }
+	],
 	"properties": {
 		"title": {
 			"$ref": "#/definitions/i18nObject"


### PR DESCRIPTION
Capabilities need to be either `getable`, `setable` or both but our JSON schema doesn't validate that.
This PR updates the JSON Schema for capabilities to specify that a capability must have either `getable`, `setable` or both.