### PR TITLE
feat: warn on duplicate Flow card ids

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -315,7 +315,12 @@ class App {
         if(Array.isArray(cards)) {
           for( let i = 0; i < cards.length; i++ ) {
             const card = cards[i];
-            this._validateFlowCard(card, `flow.${type}[${card.id || i}]`);
+
+            if (cards.findIndex(other => other.id === card.id) !== i) {
+              console.warn(`Warning: found multiple Flow card ${type} with the id "${card.id}", all Flow cards should have a unique id.`);
+            }
+
+            this._validateFlowCard(card, `flow.${type}.${card.id}`);
           }
         }
       }


### PR DESCRIPTION
This is a warning instead of an error so existing apps continue to work, in the future this should be turned into a hard error.