### PR TITLE
Fix Typo in battery capability

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -45,7 +45,7 @@ const IMAGE_SIZES = {
 }
 const BATTERY_CAPABILITIES = [
   'measure_battery',
-  'alarm_batter',
+  'alarm_battery',
 ];
 
 class App {


### PR DESCRIPTION
I noticed a typo in BATTERY_CAPABILITIES - it is used to warn a developer when a device uses batteries but no battery type is specified in the manifest. This typo should also add this warning when using alarm_battery. ﻿
