### PR TITLE
fix: validate setting id

### DIFF
--- a/assets/app/schema.json
+++ b/assets/app/schema.json
@@ -540,14 +540,7 @@
                 ]
               },
               "id": {
-                "oneOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "number"
-                  }
-                ]
+                "type": "string"
               },
               "label": {
                 "$ref": "#/definitions/i18nObject"
@@ -582,14 +575,7 @@
                 ]
               },
               "id": {
-                "oneOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "number"
-                  }
-                ]
+                "type": "string"
               },
               "label": {
                 "$ref": "#/definitions/i18nObject"
@@ -640,14 +626,7 @@
                 ]
               },
               "id": {
-                "oneOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "number"
-                  }
-                ]
+                "type": "string"
               },
               "label": {
                 "$ref": "#/definitions/i18nObject"
@@ -696,14 +675,7 @@
                 ]
               },
               "id": {
-                "oneOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "number"
-                  }
-                ]
+                "type": "string"
               },
               "label": {
                 "$ref": "#/definitions/i18nObject"


### PR DESCRIPTION
In device.settings object keys that are numbers are converted to strings anyway. So having id 1 would overwrite something with id "1" and vice versa.

- only allow strings