### PR TITLE
better error paths

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -113,7 +113,7 @@ class App {
     const ajv = new Ajv({ async: true, allErrors: true });
     const validate = ajv.compile(schema);
     const valid = await validate(appJson);
-    if (valid === false) throw new Error(this.constructor.errorsText(validate.errors) || 'Invalid app.json');
+    if (valid === false) throw new Error(this.constructor.errorsText(validate.errors, appJson) || 'Invalid app.json');
 
     // validate `appJson.id`
     if (!App.isValidId(appJson.id)) {
@@ -704,11 +704,47 @@ class App {
     return brandColor;
   }
 
-  static errorsText(errors) {
+  static errorsText(errors, appJson) {
     if (Array.isArray(errors) === false) return null;
 
     return errors.reduce((message, error) => {
       let info = '';
+
+      // Replace `drivers[0]` with `drivers['driver_id']`
+      const regex = new RegExp('drivers\\[(\\d+)\\]');
+      const match = error.dataPath.match(regex);
+      if (match) {
+        const index = parseInt(match[1], 10);
+        const driver = appJson.drivers[index];
+        if (driver) {
+          error.dataPath = error.dataPath.replace(`drivers[${index}]`, `drivers['${driver.id}']`);
+        }
+      }
+
+      // Replace `flow.actions[0].args[0]` with `flow.actions['my_card_id'].args['my_arg_id']`
+      ['triggers', 'conditions', 'actions'].forEach(type => {
+        const regex = new RegExp(`flow.${type}\\[(\\d+)\\]`);
+        const match = error.dataPath.match(regex);
+        if (match) {
+          const index = parseInt(match[1], 10);
+          const card = appJson.flow[type][index];
+          if (card) {
+            error.dataPath = error.dataPath.replace(`flow.${type}[${index}]`, `flow.${type}['${card.id}']`);
+
+            // Replace args
+            const regex = new RegExp('.args\\[(\\d+)\\]');
+            const match = error.dataPath.match(regex);
+            if (match) {
+              const index = parseInt(match[1], 10);
+              const arg = card.args[index];
+              if (arg) {
+                error.dataPath = error.dataPath.replace(`.args[${index}]`, `.args['${arg.name}']`);
+              }
+            }
+          }
+        }
+      });
+
       switch (error.keyword) {
         case 'oneOf':
           return `${message}manifest${error.dataPath} matched no available schemas, see previous errors\n`;


### PR DESCRIPTION
This PR replaces the following strings from AJV for more helpful error messages:

* Replaces `drivers[0]` with `drivers['driver_id']`
* Replaces `flow.actions[0].args[0]` with `flow.actions['my_card_id'].args['my_arg_id']`