### PR TITLE
`garagedoor_closed_false` Norwegian title

### DIFF
--- a/assets/capability/capabilities/garagedoor_closed.json
+++ b/assets/capability/capabilities/garagedoor_closed.json
@@ -39,7 +39,7 @@
           "fr": "Ouvert",
           "it": "Aperte",
           "sv": "Öppen",
-          "no": "Åpen",
+          "no": "Åpnet",
           "es": "Abiertos",
           "da": "Åben"
         }


### PR DESCRIPTION
In Norwegian, `Opened` is `Åpnet` and not `Åpen`.

Using `Åpen` here would be like saying `I open the garage door` which is a bad choice of word