### PR TITLE
fix: make flow manifest platforms property optional

### DIFF
--- a/assets/app/schema.json
+++ b/assets/app/schema.json
@@ -74,9 +74,6 @@
         "id",
         "title"
       ],
-      "requiredVerified": [
-        "platforms"
-      ],
       "properties": {
         "id": {
           "type": "string"


### PR DESCRIPTION
make flow manifest platforms property optional