### PR TITLE
fix: downgrade flow card id unique error to warning

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -371,7 +371,7 @@ class App {
             const card = cards[i];
 
             if (cards.findIndex(other => other.id === card.id) !== i) {
-              throw new Error(`Found multiple Flow card ${type} with the id "${card.id}", all Flow cards should have a unique id.`);
+              console.warn(`Warning: Found multiple Flow card ${type} with the id "${card.id}", all Flow cards should have a unique id.`);
             }
 
             this._validateFlowCard(card, `flow.${type}.${card.id}`, appJson, {


### PR DESCRIPTION
Fixes https://github.com/athombv/homey-apps-sdk-issues/issues/221

As mentioned there apps may have already been using duplicate Flow card ids and cannot remove them without introducing breakage. It is still a footgun so we will print a warning which is annoying for those few apps.

This used to be a warning but was upgraded to an error in: https://github.com/athombv/node-homey-lib/commit/e9f84b87c73f55722d3221a706c6a603ec14eedd

Maybe we want to error for verified apps and warn for other levels?