### PR TITLE
feat: warn if driver is missing platforms

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -282,6 +282,10 @@ class App {
         }
 
         // validate `appJson.drivers[].platforms`
+        if (driver.platforms) {
+          console.warn(`Warning: drivers.${driver.id} doesn't have a 'platforms' property.`);
+        }
+
         if (driver.platforms && appJson.platforms) {
           if (driver.platforms.includes('local')) {
             if (appJson.platforms.includes('local') === false) {

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -282,7 +282,7 @@ class App {
         }
 
         // validate `appJson.drivers[].platforms`
-        if (!driver.platforms) {
+        if (!driver.platforms && appJson.platforms && appJson.platforms.includes('cloud')) {
           console.warn(`Warning: drivers.${driver.id} doesn't have a 'platforms' property. The default is ["local"].`);
         }
 

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -283,7 +283,7 @@ class App {
 
         // validate `appJson.drivers[].platforms`
         if (!driver.platforms) {
-          console.warn(`Warning: drivers.${driver.id} doesn't have a 'platforms' property.`);
+          console.warn(`Warning: drivers.${driver.id} doesn't have a 'platforms' property. The default is ["local"].`);
         }
 
         if (driver.platforms && appJson.platforms) {

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -282,7 +282,7 @@ class App {
         }
 
         // validate `appJson.drivers[].platforms`
-        if (driver.platforms) {
+        if (!driver.platforms) {
           console.warn(`Warning: drivers.${driver.id} doesn't have a 'platforms' property.`);
         }
 


### PR DESCRIPTION
Missing `"platforms"` on a driver causes some very confusing behaviour when running an app on cloud.
We can't really error but we probably do want to warn that it is missing.