### PR TITLE
fix: improve required errors for validation levels

### DIFF
--- a/assets/app/schema.json
+++ b/assets/app/schema.json
@@ -926,11 +926,6 @@
     "compatibility",
     "author"
   ],
-  "requiredPublish": [
-    "category",
-    "images",
-    "brandColor"
-  ],
   "requiredVerified": [
     "platforms",
     "support"
@@ -1089,9 +1084,6 @@
           "name",
           "class",
           "capabilities"
-        ],
-        "requiredPublish": [
-          "images"
         ],
         "requiredVerified": [
           "platforms",

--- a/assets/app/schema.json
+++ b/assets/app/schema.json
@@ -926,10 +926,6 @@
     "compatibility",
     "author"
   ],
-  "requiredVerified": [
-    "platforms",
-    "support"
-  ],
   "properties": {
     "id": {
       "type": "string"
@@ -1084,10 +1080,6 @@
           "name",
           "class",
           "capabilities"
-        ],
-        "requiredVerified": [
-          "platforms",
-          "connectivity"
         ],
         "properties": {
           "id": {

--- a/assets/app/schema.json
+++ b/assets/app/schema.json
@@ -211,9 +211,6 @@
                   "name",
                   "type"
                 ],
-                "requiredVerified": [
-                  "title"
-                ],
                 "properties": {
                   "title": {
                     "$ref": "#/definitions/i18nObject"
@@ -252,9 +249,6 @@
                 "required": [
                   "name",
                   "type"
-                ],
-                "requiredVerified": [
-                  "title"
                 ],
                 "properties": {
                   "title": {
@@ -299,9 +293,6 @@
                   "name",
                   "type",
                   "values"
-                ],
-                "requiredVerified": [
-                  "title"
                 ],
                 "properties": {
                   "title": {

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -27,11 +27,12 @@ const {
   dirname,
 } = require('../../helpers');
 
-const VALIDATION_LEVELS = [
-  'debug',
-  'publish',
-  'verified',
-];
+const VALIDATION_LEVELS = {
+  DEBUG: 0,
+  PUBLISH: 1,
+  VERIFIED: 2,
+};
+
 const IMAGE_MARKERS = {
   '.jpg': Buffer.from([0xFF, 0xD8]),
   '.jpeg': Buffer.from([0xFF, 0xD8]),
@@ -77,12 +78,17 @@ class App {
 
     this.debug(`Validating "${this._path}"`);
 
+    // Map level from string to number
+    level = VALIDATION_LEVELS[level.toUpperCase()];
+
     if (!VALIDATION_LEVELS.includes(level)) {
       throw new Error(`Invalid validation level. Allowed levels are: ${VALIDATION_LEVELS}`);
     }
 
-    const levelPublish = (level === 'publish' || level === 'verified');
-    const levelVerified = (level === 'verified');
+    if (Object.values(VALIDATION_LEVELS).includes(level) === false) {
+      const levels = Object.keys(VALIDATION_LEVELS).map(key => key.toLowerCase());
+      throw new Error(`Invalid validation level. Allowed levels are: ${levels.join(', ')}`);
+    }
 
     let appJson = await readFileAsync(join(this._path, 'app.json'));
     appJson = JSON.parse(appJson);
@@ -92,7 +98,7 @@ class App {
     // Merge required, requiredPublish && requiredVerified
     this.constructor.loopObjectRecursive(schema, obj => {
       if (obj['requiredPublish']) {
-        if (levelPublish) {
+        if (level >= VALIDATION_LEVELS.PUBLISH) {
           obj.required = [...(obj.required || []), ...obj['requiredPublish'].filter(key => !obj.required.includes(key))];
         } else {
           delete obj['requiredPublish'];
@@ -100,7 +106,7 @@ class App {
       }
 
       if (obj['requiredVerified']) {
-        if (levelVerified) {
+        if (level >= VALIDATION_LEVELS.VERIFIED) {
           obj.required = [...(obj.required || []), ...obj['requiredVerified'].filter(key => !obj.required.includes(key))];
         } else {
           delete obj['requiredVerified'];
@@ -152,8 +158,10 @@ class App {
           throw new Error(`Forbidden permission: ${permission}`);
         }
 
-        if (permission === 'homey:manager:api' && levelPublish) {
-          console.warn('Warning: using the homey:manager:api permission will require a more thorough review. It may take longer than usual to review your app.');
+        if (permission === 'homey:manager:api') {
+          if (level >= VALIDATION_LEVELS.PUBLISH) {
+            console.warn('Warning: using the homey:manager:api permission will require a more thorough review. It may take longer than usual to review your app.');
+          }
         }
 
         if (permission.startsWith('homey:app:')) return;
@@ -211,7 +219,7 @@ class App {
           // validate battery
           if (BATTERY_CAPABILITIES.includes(capabilityId)) {
             if (!driver.energy || !Array.isArray(driver.energy.batteries)) {
-              if (levelPublish) {
+              if (level >= VALIDATION_LEVELS.PUBLISH) {
                 throw new Error(`drivers.${driver.id} is missing an array 'energy.batteries' because the capability ${capabilityId} is being used.`);
               }
             }
@@ -277,7 +285,7 @@ class App {
         }
 
         // validate `appJson.drivers[].images`
-        if (levelPublish) {
+        if (level >= VALIDATION_LEVELS.PUBLISH) {
           await this._validateImages(driver.images, 'driver');
         }
 
@@ -378,10 +386,7 @@ class App {
               }
             }
 
-            this._validateFlowCard(card, `flow.${type}.${card.id}`, appJson, {
-              levelPublish,
-              levelVerified,
-            });
+            this._validateFlowCard(card, `flow.${type}.${card.id}`, appJson, level);
           }
         }
       }
@@ -457,7 +462,7 @@ class App {
       await this._ensureFileExistsCaseSensitive(join('settings', 'index.html'));
     }
 
-    if (levelPublish) {
+    if (level >= VALIDATION_LEVELS.PUBLISH) {
       await this._validateImages(appJson.images, 'app');
       await this._validateModules();
     }
@@ -580,7 +585,7 @@ class App {
     }
   }
 
-  _validateFlowCard(card, errorPath, appJson, { levelPublish, levelVerified }) {
+  _validateFlowCard(card, errorPath, appJson, level) {
     if (Array.isArray(card.args) === false) return;
 
     let foundFirstDevice = false;
@@ -603,7 +608,7 @@ class App {
     }
 
     if (typeof card.titleFormatted === 'undefined') {
-      if (levelVerified) {
+      if (level >= VALIDATION_LEVELS.VERIFIED) {
         throw new Error(`${errorPath}.titleFormatted is missing.`);
       } else {
         console.warn(`Warning: ${errorPath}.titleFormatted is missing. Specifying a Flow card's formatted title will be required in the future.`);

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -28,11 +28,11 @@ const {
   dirname,
 } = require('../../helpers');
 
-const VALIDATION_LEVELS = {
-  DEBUG: 0,
-  PUBLISH: 1,
-  VERIFIED: 2,
-};
+const VALIDATION_LEVELS = [
+  'debug',
+  'publish',
+  'verified',
+];
 
 const IMAGE_MARKERS = {
   '.jpg': Buffer.from([0xFF, 0xD8]),
@@ -79,17 +79,12 @@ class App {
 
     this.debug(`Validating "${this._path}"`);
 
-    // Map level from string to number
-    level = VALIDATION_LEVELS[level.toUpperCase()];
-
     if (!VALIDATION_LEVELS.includes(level)) {
       throw new Error(`Invalid validation level. Allowed levels are: ${VALIDATION_LEVELS}`);
     }
 
-    if (Object.values(VALIDATION_LEVELS).includes(level) === false) {
-      const levels = Object.keys(VALIDATION_LEVELS).map(key => key.toLowerCase());
-      throw new Error(`Invalid validation level. Allowed levels are: ${levels.join(', ')}`);
-    }
+    const levelPublish = (level === 'publish' || level === 'verified');
+    const levelVerified = (level === 'verified');
 
     let appJson = await readFileAsync(join(this._path, 'app.json'));
     appJson = JSON.parse(appJson);
@@ -131,7 +126,7 @@ class App {
       }
     }
 
-    if (level >= VALIDATION_LEVELS.VERIFIED) {
+    if (levelVerified) {
       if (appJson.platforms === undefined) {
         throw new Error('The property `platforms` is required in order to publish a verified app.');
       }
@@ -151,7 +146,7 @@ class App {
         }
 
         if (permission === 'homey:manager:api') {
-          if (level >= VALIDATION_LEVELS.PUBLISH) {
+          if (levelPublish) {
             console.warn('Warning: using the homey:manager:api permission will require a more thorough review. It may take longer than usual to review your app.');
           }
         }
@@ -180,7 +175,7 @@ class App {
           throw new Error(`Invalid category: ${category}`);
         }
       });
-    } else if (level >= VALIDATION_LEVELS.PUBLISH) {
+    } else if (levelPublish) {
       throw new Error('The property `category` is required in order to publish an app.');
     }
 
@@ -213,7 +208,7 @@ class App {
           // validate battery
           if (BATTERY_CAPABILITIES.includes(capabilityId)) {
             if (!driver.energy || !Array.isArray(driver.energy.batteries)) {
-              if (level >= VALIDATION_LEVELS.PUBLISH) {
+              if (levelPublish) {
                 throw new Error(`drivers.${driver.id} is missing an array 'energy.batteries' because the capability ${capabilityId} is being used.`);
               }
             }
@@ -279,11 +274,11 @@ class App {
         }
 
         // validate `appJson.drivers[].images`
-        if (level >= VALIDATION_LEVELS.PUBLISH) {
+        if (levelPublish) {
           await this._validateImages(driver.images, 'driver');
         }
 
-        if (level >= VALIDATION_LEVELS.VERIFIED) {
+        if (levelVerified) {
           if (driver.platforms === undefined) {
             throw new Error(`drivers.${driver.id}: property \`platforms\` is required in order to publish a verified app.`);
           }
@@ -390,7 +385,7 @@ class App {
               }
             }
 
-            this._validateFlowCard(card, `flow.${type}.${card.id}`, appJson, level);
+            this._validateFlowCard(card, `flow.${type}.${card.id}`, appJson, { levelPublish, levelVerified });
           }
         }
       }
@@ -466,7 +461,7 @@ class App {
       await this._ensureFileExistsCaseSensitive(join('settings', 'index.html'));
     }
 
-    if (level >= VALIDATION_LEVELS.PUBLISH) {
+    if (levelPublish) {
       await this._validateImages(appJson.images, 'app');
       await this._validateModules();
     }
@@ -475,7 +470,7 @@ class App {
       if (!this.constructor.isValidBrandColor(appJson.brandColor)) {
         throw new Error('The color defined in `brandColor` is too bright. Icons are rendered white, so choose a darker color that has enough contrast.');
       }
-    } else if (level >= VALIDATION_LEVELS.PUBLISH) {
+    } else if (levelPublish) {
       throw new Error('The property `brandColor` is required in order to publish an app.');
     }
 
@@ -591,7 +586,7 @@ class App {
     }
   }
 
-  _validateFlowCard(card, errorPath, appJson, level) {
+  _validateFlowCard(card, errorPath, appJson, { levelPublish, levelVerified }) {
     if (Array.isArray(card.args) === false) return;
 
     const firstDeviceArgument = card.args.find(argument => {
@@ -606,7 +601,7 @@ class App {
 
     if (filteredCardArgs.length === 0) return;
 
-    if (level >= VALIDATION_LEVELS.VERIFIED) {
+    if (levelVerified) {
       for (const argument of filteredCardArgs) {
         if (argument.title === undefined) {
           throw new Error(`${errorPath}: property \`title\` is required for arguments in order to publish a verified app.`);
@@ -618,7 +613,7 @@ class App {
       filteredCardArgs.push({ name: 'droptoken' });
     }
 
-    if (level >= VALIDATION_LEVELS.VERIFIED) {
+    if (levelVerified) {
       if (card.titleFormatted === undefined) {
         throw new Error(`${errorPath}: property \`titleFormatted\` is required in order to publish a verified app.`);
       }

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -141,6 +141,16 @@ class App {
       }
     }
 
+    if (level >= VALIDATION_LEVELS.VERIFIED) {
+      if (appJson.platforms === undefined) {
+        throw new Error('The property `platforms` is required in order to publish a verified app.');
+      }
+
+      if (appJson.support === undefined) {
+        throw new Error('The property `support` is required in order to publish a verified app.');
+      }
+    }
+
     // validate `appJson.permissions`
     if (Array.isArray(appJson.permissions)) {
       const allowedPermissions = App.getPermissions();
@@ -281,6 +291,16 @@ class App {
         // validate `appJson.drivers[].images`
         if (level >= VALIDATION_LEVELS.PUBLISH) {
           await this._validateImages(driver.images, 'driver');
+        }
+
+        if (level >= VALIDATION_LEVELS.VERIFIED) {
+          if (appJson.platforms === undefined) {
+            throw new Error(`drivers.${driver.id}: property \`platforms\` is required in order to publish a verified app.`);
+          }
+
+          if (appJson.connectivity === undefined) {
+            throw new Error(`drivers.${driver.id}: property \`connectivity\` is required in order to publish a verified app.`);
+          }
         }
 
         // validate `appJson.drivers[].platforms`
@@ -603,12 +623,14 @@ class App {
       filteredCardArgs.push({ name: 'droptoken' });
     }
 
-    if (typeof card.titleFormatted === 'undefined') {
-      if (level >= VALIDATION_LEVELS.VERIFIED) {
-        throw new Error(`${errorPath}.titleFormatted is missing.`);
-      } else {
-        console.warn(`Warning: ${errorPath}.titleFormatted is missing. Specifying a Flow card's formatted title will be required in the future.`);
+    if (level >= VALIDATION_LEVELS.VERIFIED) {
+      if (card.titleFormatted === undefined) {
+        throw new Error(`${errorPath}: property \`titleFormatted\` is required in order to publish a verified app.`);
       }
+    }
+
+    if (typeof card.titleFormatted === 'undefined') {
+      console.warn(`Warning: ${errorPath}.titleFormatted is missing. Specifying a Flow card's formatted title will be required in the future.`);
     }
 
     if (typeof card.titleFormatted === 'string') {

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -3,7 +3,8 @@
 
 'use strict';
 
-const querystring = require('querystring');
+const { URLSearchParams } = require('url');
+
 const Ajv = require('ajv');
 const semver = require('semver');
 const tinycolor = require('tinycolor2');
@@ -26,7 +27,6 @@ const {
   basename,
   dirname,
 } = require('../../helpers');
-const { URLSearchParams } = require('url');
 
 const VALIDATION_LEVELS = {
   DEBUG: 0,

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -95,16 +95,8 @@ class App {
 
     const schema = App.getJSONSchema();
 
-    // Merge required, requiredPublish && requiredVerified
+    // Merge required requiredVerified
     this.constructor.loopObjectRecursive(schema, obj => {
-      if (obj['requiredPublish']) {
-        if (level >= VALIDATION_LEVELS.PUBLISH) {
-          obj.required = [...(obj.required || []), ...obj['requiredPublish'].filter(key => !obj.required.includes(key))];
-        } else {
-          delete obj['requiredPublish'];
-        }
-      }
-
       if (obj['requiredVerified']) {
         if (level >= VALIDATION_LEVELS.VERIFIED) {
           obj.required = [...(obj.required || []), ...obj['requiredVerified'].filter(key => !obj.required.includes(key))];
@@ -173,7 +165,7 @@ class App {
     }
 
     // validate `appJson.category`
-    if (typeof appJson.category !== 'undefined') {
+    if (appJson.category) {
       const allowedCategories = App.getCategories();
       let categories = [];
 
@@ -188,6 +180,8 @@ class App {
           throw new Error(`Invalid category: ${category}`);
         }
       });
+    } else if (level >= VALIDATION_LEVELS.PUBLISH) {
+      throw new Error('The property `category` is required in order to publish an app.');
     }
 
     // validate `appJson.drivers`
@@ -471,6 +465,8 @@ class App {
       if (!this.constructor.isValidBrandColor(appJson.brandColor)) {
         throw new Error('The color defined in `brandColor` is too bright. Icons are rendered white, so choose a darker color that has enough contrast.');
       }
+    } else if (level >= VALIDATION_LEVELS.PUBLISH) {
+      throw new Error('The property `brandColor` is required in order to publish an app.');
     }
 
     this.debug('Validated successfully');

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -284,11 +284,11 @@ class App {
         }
 
         if (level >= VALIDATION_LEVELS.VERIFIED) {
-          if (appJson.platforms === undefined) {
+          if (driver.platforms === undefined) {
             throw new Error(`drivers.${driver.id}: property \`platforms\` is required in order to publish a verified app.`);
           }
 
-          if (appJson.connectivity === undefined) {
+          if (driver.connectivity === undefined) {
             throw new Error(`drivers.${driver.id}: property \`connectivity\` is required in order to publish a verified app.`);
           }
         }

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -26,6 +26,7 @@ const {
   basename,
   dirname,
 } = require('../../helpers');
+const { URLSearchParams } = require('url');
 
 const VALIDATION_LEVELS = {
   DEBUG: 0,
@@ -94,17 +95,6 @@ class App {
     appJson = JSON.parse(appJson);
 
     const schema = App.getJSONSchema();
-
-    // Merge required requiredVerified
-    this.constructor.loopObjectRecursive(schema, obj => {
-      if (obj['requiredVerified']) {
-        if (level >= VALIDATION_LEVELS.VERIFIED) {
-          obj.required = [...(obj.required || []), ...obj['requiredVerified'].filter(key => !obj.required.includes(key))];
-        } else {
-          delete obj['requiredVerified'];
-        }
-      }
-    });
 
     const ajv = new Ajv({ async: true, allErrors: true });
     const validate = ajv.compile(schema);
@@ -604,20 +594,25 @@ class App {
   _validateFlowCard(card, errorPath, appJson, level) {
     if (Array.isArray(card.args) === false) return;
 
-    let foundFirstDevice = false;
+    const firstDeviceArgument = card.args.find(argument => {
+      const filter = new URLSearchParams(argument.filter);
+      return argument.type === 'device' && (filter.has('driver_id') || filter.has('driverId'));
+    });
 
     // Filter to valid arguments for flow card titles
-    const filteredCardArgs = card.args.filter(arg => {
-      if (foundFirstDevice) return true;
-      if (arg.type !== 'device') return true;
-      if (!arg.filter) return true;
-      const query = querystring.parse(arg.filter);
-      if (!query.driver_id && !query.driverId) return true;
-      foundFirstDevice = true;
-      return false;
+    const filteredCardArgs = card.args.filter(argument => {
+      return argument !== firstDeviceArgument;
     });
 
     if (filteredCardArgs.length === 0) return;
+
+    if (level >= VALIDATION_LEVELS.VERIFIED) {
+      for (const argument of filteredCardArgs) {
+        if (argument.title === undefined) {
+          throw new Error(`${errorPath}: property \`title\` for is required for arguments in order to publish a verified app.`);
+        }
+      }
+    }
 
     if (card.droptoken) {
       filteredCardArgs.push({ name: 'droptoken' });
@@ -821,16 +816,6 @@ class App {
 
       return `${message}manifest${error.dataPath} ${error.message} ${info}\n`;
     }, '').slice(0, -1); // remove final '\n' character
-  }
-
-  static loopObjectRecursive(obj, cb) {
-    cb(obj);
-    for (const value of Object.values(obj)) {
-      cb(value);
-      if (typeof value === 'object' && value !== null) {
-        this.loopObjectRecursive(value, cb);
-      }
-    }
   }
 
 }

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -275,6 +275,9 @@ class App {
 
         // validate `appJson.drivers[].images`
         if (levelPublish) {
+          if (!driver.images) {
+            throw new Error(`drivers.${driver.id}: property \`images\` is required in order to publish an app.`);
+          }
           await this._validateImages(driver.images, 'driver');
         }
 
@@ -462,6 +465,9 @@ class App {
     }
 
     if (levelPublish) {
+      if (!appJson.images) {
+        throw new Error('The property `images` is required in order to publish an app.');
+      }
       await this._validateImages(appJson.images, 'app');
       await this._validateModules();
     }

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -609,7 +609,7 @@ class App {
     if (level >= VALIDATION_LEVELS.VERIFIED) {
       for (const argument of filteredCardArgs) {
         if (argument.title === undefined) {
-          throw new Error(`${errorPath}: property \`title\` for is required for arguments in order to publish a verified app.`);
+          throw new Error(`${errorPath}: property \`title\` is required for arguments in order to publish a verified app.`);
         }
       }
     }

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -619,14 +619,12 @@ class App {
       filteredCardArgs.push({ name: 'droptoken' });
     }
 
-    if (levelVerified) {
-      if (card.titleFormatted === undefined) {
+    if (card.titleFormatted === undefined) {
+      if (levelVerified) {
         throw new Error(`${errorPath}: property \`titleFormatted\` is required in order to publish a verified app.`);
+      } else {
+        console.warn(`Warning: ${errorPath}.titleFormatted is missing. Specifying a Flow card's formatted title will be required in the future.`);
       }
-    }
-
-    if (typeof card.titleFormatted === 'undefined') {
-      console.warn(`Warning: ${errorPath}.titleFormatted is missing. Specifying a Flow card's formatted title will be required in the future.`);
     }
 
     if (typeof card.titleFormatted === 'string') {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.13.5",
   "description": "Shared Library for Homey",
   "main": "index.js",
+  "engines": {
+    "node": ">=12.13.0"
+  },
   "scripts": {
     "build": "npm ci; npm run pack",
     "pack": "webpack",

--- a/test/validate-base-manifest.js
+++ b/test/validate-base-manifest.js
@@ -75,8 +75,8 @@ describe('HomeyLib.App#validate() base manifest', function() {
 
     await assertValidates(app, {
       debug: true, // brandColor is optional for debug
-      publish: /should have required property 'brandColor'/i,
-      verified: /should have required property 'brandColor'/i,
+      publish: /property `brandColor` is required/i,
+      verified: /property `brandColor` is required/i,
     });
   });
 
@@ -223,7 +223,7 @@ describe('HomeyLib.App#validate() base manifest', function() {
     await assertValidates(app, {
       debug: true, // platforms is optional for debug
       publish: true, // platforms is optional for publish
-      verified: /should have required property 'platforms'/i,
+      verified: /property `platforms` is required/i,
     });
   });
 
@@ -252,8 +252,8 @@ describe('HomeyLib.App#validate() base manifest', function() {
 
     await assertValidates(app, {
       debug: true, // category is optional for debug
-      publish: /should have required property 'category'/i,
-      verified: /should have required property 'category'/i,
+      publish: /property `category` is required/i,
+      verified: /property `category` is required/i,
     });
   });
 
@@ -312,8 +312,8 @@ describe('HomeyLib.App#validate() base manifest', function() {
 
     await assertValidates(app, {
       debug: true, // debug does not validate images
-      publish: /should have required property 'images'/i,
-      verified: /should have required property 'images'/i,
+      publish: /property `images` is required/i,
+      verified: /property `images` is required/i,
     });
   });
 
@@ -411,7 +411,7 @@ describe('HomeyLib.App#validate() base manifest', function() {
     await assertValidates(app, {
       debug: true, // support is optional for debug
       publish: true, // support is optional for publish
-      verified: /should have required property 'support'/i,
+      verified: /property `support` is required/i,
     });
   });
 

--- a/test/validate-driver-manifest.js
+++ b/test/validate-driver-manifest.js
@@ -152,8 +152,8 @@ describe('HomeyLib.App#validate() driver manifest', function() {
 
     await assertValidates(app, {
       debug: true, // debug does not validate images
-      publish: /should have required property 'images'/i,
-      verified: /should have required property 'images'/i,
+      publish: /property `images` is required/i,
+      verified: /property `images` is required/i,
     });
   });
 
@@ -193,7 +193,7 @@ describe('HomeyLib.App#validate() driver manifest', function() {
     await assertValidates(app, {
       debug: true, // platforms is optional for debug, but will warn
       publish: true, // platforms is optional for publish, but will warn
-      verified: /should have required property 'platforms'/i,
+      verified: /property `platforms` is required/i,
     });
   });
 
@@ -229,7 +229,7 @@ describe('HomeyLib.App#validate() driver manifest', function() {
     await assertValidates(app, {
       debug: true, // connectivity is optional for debug
       publish: true, // connectivity is optional for publish
-      verified: /should have required property 'connectivity'/i,
+      verified: /property `connectivity` is required/i,
     });
   });
 

--- a/test/validate-files.js
+++ b/test/validate-files.js
@@ -35,8 +35,8 @@ describe('HomeyLib.App#validate() files', function() {
 
     await assertValidates(app, {
       debug: true,
-      publish: /should have required property/i,
-      verified: /should have required property/i,
+      publish: /property `category` is required/i,
+      verified: /property `platforms` is required/i,
     });
   });
 
@@ -64,7 +64,7 @@ describe('HomeyLib.App#validate() files', function() {
     await assertValidates(app, {
       debug: true,
       publish: true,
-      verified: /should have required property/i,
+      verified: /property `platforms` is required/i,
     });
   });
 


### PR DESCRIPTION
Remove the `requiredVerified` and `requiredPublish` options from the JSON Schema, the checks are moved to after AJV has checked the schema. This allows us to improve the error message to mention that the error is _because_ of the validation level.