### PR TITLE
feat: add tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: Test
+
+# Optional secrets:
+# - SSH_KEY: if `npm ci` needs to install private npm packages, make sure to enable webfactory/ssh-agent@v0.2.0 step
+
+# GitHub repo configuration:
+# 1. If you have protected branches, go to Branches > edit protected branch > enable 'Require status checks to pass before 
+#    merging' and select the 'Test' status check.
+
+# Note: make sure to commit package-lock.json, this is needed for `npm ci`.
+
+# Defines the trigger for this action (by default on push to master/production and on all pull requests)
+# For more information see: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#about-workflow-events)
+on:
+  push:
+    branches:
+      - master
+      - production
+  pull_request:
+
+jobs:
+  test:
+    name: Run
+    runs-on: ubuntu-latest
+
+    # Define a strategy for running these tests on various operating systems and Node.js versions in parallel.
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        node: [12, 14, 16]
+
+    steps:
+      # Checks out the current repository.
+      - uses: actions/checkout@v2
+
+      # Configures a Node.js environment.
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }} # Important: use the matrix.node property when using a matrix strategy
+      
+      # Set SSH key
+      - uses: webfactory/ssh-agent@v0.4.1
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+        if: env.SSH_KEY != null
+        with:
+          ssh-private-key: ${{ env.SSH_KEY }}
+
+      # Run `npm ci` to re-create your local environment (make sure to commit your package-lock.json!).
+      # Finally run `npm test` (make sure you have defined a proper test command in package.json).
+      - run: npm ci
+      - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,7 @@ jobs:
     # Define a strategy for running these tests on various operating systems and Node.js versions in parallel.
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-        node: [12, 14, 16]
+        node: [12, 16]
 
     steps:
       # Checks out the current repository.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Homey Library
 
+[![Test](https://github.com/athombv/node-homey-lib/actions/workflows/test.yml/badge.svg)](https://github.com/athombv/node-homey-lib/actions/workflows/test.yml)
+
 This library contains shared code between Homey, Homey Apps, Athom CLI, Athom Developer and others.
 
 This library can, among other things:

--- a/package-lock.json
+++ b/package-lock.json
@@ -264,6 +264,12 @@
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
     },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -512,6 +518,12 @@
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
     },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -526,7 +538,6 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -766,8 +777,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "bindings": {
       "version": "1.5.0",
@@ -834,6 +844,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "browserify-aes": {
@@ -1023,6 +1039,29 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "set-value": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+          "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+          }
+        }
       }
     },
     "call-bind": {
@@ -1041,6 +1080,12 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "camelcase": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
+      "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -1057,7 +1102,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
       "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -1074,7 +1118,6 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "fill-range": "^7.0.1"
           }
@@ -1084,7 +1127,6 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "to-regex-range": "^5.0.1"
           }
@@ -1094,7 +1136,6 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^2.1.1"
           }
@@ -1103,15 +1144,13 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "to-regex-range": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-number": "^7.0.0"
           }
@@ -1161,6 +1200,17 @@
             "is-descriptor": "^0.1.0"
           }
         }
+      }
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       }
     },
     "clone-deep": {
@@ -1375,6 +1425,12 @@
         "ms": "2.0.0"
       }
     },
+    "decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -1446,6 +1502,12 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -1633,6 +1695,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -2465,6 +2533,12 @@
         "locate-path": "^2.0.0"
       }
     },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
+    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -2564,6 +2638,12 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
     "get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -2606,7 +2686,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "^4.0.1"
       },
@@ -2616,7 +2695,6 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^2.1.1"
           }
@@ -2636,6 +2714,12 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "has": {
@@ -2742,6 +2826,12 @@
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
       }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -2954,7 +3044,6 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -3046,6 +3135,12 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
     "is-glob": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
@@ -3087,6 +3182,12 @@
       "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
       "dev": true
     },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -3095,6 +3196,12 @@
       "requires": {
         "isobject": "^3.0.1"
       }
+    },
+    "is-primitive": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.1.tgz",
+      "integrity": "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==",
+      "dev": true
     },
     "is-regex": {
       "version": "1.1.3",
@@ -3126,6 +3233,12 @@
       "requires": {
         "has-symbols": "^1.0.2"
       }
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -3277,6 +3390,67 @@
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
+    },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "lru-cache": {
       "version": "5.1.1",
@@ -3467,6 +3641,171 @@
         "minimist": "^1.2.5"
       }
     },
+    "mocha": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
+      "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+      "dev": true,
+      "requires": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.2",
+        "debug": "4.3.2",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.7",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "3.0.4",
+        "ms": "2.1.3",
+        "nanoid": "3.1.25",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "workerpool": "6.1.5",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "serialize-javascript": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+          "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "mock-fs": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.2.tgz",
+      "integrity": "sha512-YkjQkdLulFrz0vD4BfNQdQRVmgycXTV7ykuHMlyv+C8WCHazpkiQRDthwa02kSyo8wKnY9wRptHfQLgmf0eR+A==",
+      "dev": true
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -3493,6 +3832,12 @@
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "dev": true,
       "optional": true
+    },
+    "nanoid": {
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -3572,8 +3917,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "npm-run-path": {
       "version": "4.0.1",
@@ -3865,8 +4209,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -4073,7 +4416,6 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -4120,6 +4462,12 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-from-string": {
@@ -4240,26 +4588,13 @@
       }
     },
     "set-value": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
+      "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "is-plain-object": "^2.0.4",
+        "is-primitive": "^3.0.1"
       }
     },
     "setimmediate": {
@@ -4623,6 +4958,17 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
     "string.prototype.trimend": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
@@ -4650,6 +4996,15 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-bom": {
@@ -4962,6 +5317,29 @@
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "set-value": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+          "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+          }
+        }
       }
     },
     "unique-filename": {
@@ -5401,6 +5779,49 @@
         "errno": "~0.1.7"
       }
     },
+    "workerpool": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
+      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5423,6 +5844,53 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "dependencies": {
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true
+    },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "build": "npm ci; npm run pack",
     "pack": "webpack",
     "lint": "eslint .",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha --parallel"
+  },
+  "engines": {
+    "node": ">=12.13.0"
   },
   "repository": {
     "type": "git",
@@ -25,14 +28,12 @@
     "semver": "^5.7.0",
     "tinycolor2": "^1.4.1"
   },
-  "config": {
-    "npmPublishTagProduction": "latest",
-    "npmPublishTagTesting": "beta",
-    "nodeVersion": "8"
-  },
   "devDependencies": {
     "eslint": "^7.31.0",
     "eslint-config-athom": "^2.1.1",
+    "mocha": "^9.1.3",
+    "mock-fs": "^5.1.2",
+    "set-value": "^4.1.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^4.7.2"
   }

--- a/test/fixtures/mock-app.js
+++ b/test/fixtures/mock-app.js
@@ -1,0 +1,137 @@
+/* eslint-disable node/no-unpublished-require */
+
+'use strict';
+
+const path = require('path');
+const assert = require('assert');
+
+const mockFs = require('mock-fs');
+const set = require('set-value');
+
+const HomeyLib = require('../..');
+
+const PNG_HEADER = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x00, 0x49, 0x48, 0x44, 0x52,
+]);
+
+// TODO: do we want to test other image types?
+// for now we assume that if png works, the other formats will too...
+function createFakePng({ width, height }) {
+  const size = Buffer.alloc(8);
+  size.writeUInt32BE(width, 0);
+  size.writeUInt32BE(height, 4);
+
+  return Buffer.concat([PNG_HEADER, size]);
+}
+
+// This manifest is the minimum which is valid at all levels
+const baseAppManifest = {
+  id: 'test.app',
+  name: { en: 'Test' },
+  description: { en: 'Test app' },
+  brandColor: '#000000',
+  version: '1.0.0',
+  sdk: 3,
+  compatibility: '>=5.0.0',
+  platforms: ['local', 'cloud'],
+  category: ['tools'],
+  images: {
+    small: '/assets/images/small.png',
+    large: '/assets/images/large.png',
+    xlarge: '/assets/images/xlarge.png',
+  },
+  author: { name: 'Athom B.V.' },
+  support: 'mailto:support@homey.app',
+};
+
+// This manifest is the minimum which is valid at all levels
+const baseDriverManifest = {
+  id: 'test',
+  name: { en: 'Test' },
+  class: 'light',
+  capabilities: ['onoff'],
+  platforms: ['local', 'cloud'],
+  connectivity: ['cloud'],
+  images: {
+    small: '/drivers/test/assets/images/small.png',
+    large: '/drivers/test/assets/images/large.png',
+    xlarge: '/drivers/test/assets/images/xlarge.png',
+  },
+};
+
+function mockApp(manifest, { files = {}, env = {} } = {}) {
+  const appFs = {
+    assets: {
+      'icon.svg': '<svg></svg>',
+      images: {
+        'small.png': createFakePng({ width: 250, height: 175 }),
+        'large.png': createFakePng({ width: 500, height: 350 }),
+        'xlarge.png': createFakePng({ width: 1000, height: 700 }),
+      },
+    },
+    drivers: {
+      test: {
+        assets: {
+          images: {
+            'small.png': createFakePng({ width: 75, height: 75 }),
+            'large.png': createFakePng({ width: 500, height: 500 }),
+            'xlarge.png': createFakePng({ width: 1000, height: 1000 }),
+          },
+        },
+      },
+    },
+    'app.js': 'code',
+    'app.json': JSON.stringify(manifest),
+    'env.json': JSON.stringify(env),
+    // node_modules ?
+  };
+
+  // Apply filesystem overrides
+  for (const [key, value] of Object.entries(files)) {
+    set(appFs, key, value);
+  }
+
+  mockFs({
+    // create the fake app filesystem
+    test_app: appFs,
+    // ensure homey-lib can load its assets and dependencies
+    assets: mockFs.load(path.resolve(__dirname, '../../assets')),
+    node_modules: mockFs.load(path.resolve(__dirname, '../../node_modules')),
+  });
+
+  return new HomeyLib.App('test_app');
+}
+
+function clearMockApp() {
+  mockFs.restore();
+}
+
+async function assertValidates(app, { debug, publish, verified }) {
+  if (verified === true) {
+    await assert.doesNotReject(() => app.validate({ level: 'verified' }), '`verified` validation');
+  } else {
+    await assert.rejects(() => app.validate({ level: 'verified' }), verified || undefined, '`verified` validation');
+  }
+
+  if (publish === true) {
+    await assert.doesNotReject(() => app.validate({ level: 'publish' }), '`publish` validation');
+  } else {
+    await assert.rejects(() => app.validate({ level: 'publish' }), publish || undefined, '`publish` validation');
+  }
+
+  if (debug === true) {
+    await assert.doesNotReject(() => app.validate({ level: 'debug' }), '`debug` validation');
+  } else {
+    await assert.rejects(() => app.validate({ level: 'debug' }), debug || undefined, '`debug` validation');
+  }
+}
+
+module.exports = {
+  mockApp,
+  clearMockApp,
+  assertValidates,
+  createFakePng,
+  baseAppManifest,
+  baseDriverManifest,
+};

--- a/test/fixtures/mock-app.js
+++ b/test/fixtures/mock-app.js
@@ -111,19 +111,19 @@ async function assertValidates(app, { debug, publish, verified }) {
   if (verified === true) {
     await assert.doesNotReject(() => app.validate({ level: 'verified' }), '`verified` validation');
   } else {
-    await assert.rejects(() => app.validate({ level: 'verified' }), verified || undefined, '`verified` validation');
+    await assert.rejects(() => app.validate({ level: 'verified' }), verified, '`verified` validation');
   }
 
   if (publish === true) {
     await assert.doesNotReject(() => app.validate({ level: 'publish' }), '`publish` validation');
   } else {
-    await assert.rejects(() => app.validate({ level: 'publish' }), publish || undefined, '`publish` validation');
+    await assert.rejects(() => app.validate({ level: 'publish' }), publish, '`publish` validation');
   }
 
   if (debug === true) {
     await assert.doesNotReject(() => app.validate({ level: 'debug' }), '`debug` validation');
   } else {
-    await assert.rejects(() => app.validate({ level: 'debug' }), debug || undefined, '`debug` validation');
+    await assert.rejects(() => app.validate({ level: 'debug' }), debug, '`debug` validation');
   }
 }
 

--- a/test/validate-base-manifest.js
+++ b/test/validate-base-manifest.js
@@ -1,0 +1,685 @@
+/* eslint-disable node/no-unpublished-require */
+
+'use strict';
+
+const {
+  baseAppManifest,
+  mockApp,
+  clearMockApp,
+  assertValidates,
+} = require('./fixtures/mock-app');
+
+describe('HomeyLib.App#validate() base manifest', function() {
+  this.slow(500);
+
+  afterEach(function() {
+    clearMockApp();
+  });
+
+  /*
+   * App ID
+   */
+
+  it('`id` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      id: undefined,
+    });
+
+    await assertValidates(app, {
+      debug: /should have required property 'id'/i,
+      publish: /should have required property 'id'/i,
+      verified: /should have required property 'id'/i,
+    });
+  });
+
+  it('`id` needs to be a reverse DNS', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      id: 'test',
+    });
+
+    await assertValidates(app, {
+      debug: /invalid id/i,
+      publish: /invalid id/i,
+      verified: /invalid id/i,
+    });
+  });
+
+  /*
+   * App Name
+   */
+
+  it('`name` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      name: undefined,
+    });
+
+    await assertValidates(app, {
+      debug: /should have required property 'name'/i,
+      publish: /should have required property 'name'/i,
+      verified: /should have required property 'name'/i,
+    });
+  });
+
+  /*
+   * App Brand Color
+   */
+
+  it('`brandColor` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      brandColor: undefined,
+    });
+
+    await assertValidates(app, {
+      debug: true, // brandColor is optional for debug
+      publish: /should have required property 'brandColor'/i,
+      verified: /should have required property 'brandColor'/i,
+    });
+  });
+
+  it('`brandColor` needs to be a hex color', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      brandColor: 'fuchsia',
+    });
+
+    await assertValidates(app, {
+      debug: /brandColor should match pattern/i,
+      publish: /brandColor should match pattern/i,
+      verified: /brandColor should match pattern/i,
+    });
+  });
+
+  it('`brandColor` is not allowed to be too bright', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      brandColor: '#FFFFFF',
+    });
+
+    await assertValidates(app, {
+      debug: /`brandColor` is too bright/i,
+      publish: /`brandColor` is too bright/i,
+      verified: /`brandColor` is too bright/i,
+    });
+  });
+
+  /*
+   * App Version
+   */
+
+  it('`version` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      version: undefined,
+    });
+
+    await assertValidates(app, {
+      debug: /should have required property 'version'/i,
+      publish: /should have required property 'version'/i,
+      verified: /should have required property 'version'/i,
+    });
+  });
+
+  it('`version` needs to be a valid semver string', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      version: '1',
+    });
+
+    await assertValidates(app, {
+      debug: /invalid version/i,
+      publish: /invalid version/i,
+      verified: /invalid version/i,
+    });
+  });
+
+  /*
+   * App SDK version
+   */
+
+  it('`sdk` can be undefined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      sdk: undefined,
+    });
+
+    await assertValidates(app, {
+      debug: true,
+      publish: true,
+      verified: true,
+    });
+  });
+
+  it('`sdk` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      sdk: 0,
+    });
+
+    await assertValidates(app, {
+      debug: /sdk should be >= 1/i,
+      publish: /sdk should be >= 1/i,
+      verified: /sdk should be >= 1/i,
+    });
+  });
+
+  it('`sdk: 3` needs at least `compatibility: ">=5.0.0"`', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      sdk: 3,
+      compatibility: '>=4.2.0',
+    });
+
+    await assertValidates(app, {
+      debug: /sdk version 3 apps must have a compatibility of at least >=5.0.0/i,
+      publish: /sdk version 3 apps must have a compatibility of at least >=5.0.0/i,
+      verified: /sdk version 3 apps must have a compatibility of at least >=5.0.0/i,
+    });
+  });
+
+  /*
+   * App Compatibility
+   */
+
+  it('`compatibility` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      compatibility: undefined,
+    });
+
+    await assertValidates(app, {
+      debug: /should have required property 'compatibility'/i,
+      publish: /should have required property 'compatibility'/i,
+      verified: /should have required property 'compatibility'/i,
+    });
+  });
+
+  it('`compatibility` needs to be a valid semver string', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      compatibility: '1',
+    });
+
+    await assertValidates(app, {
+      debug: /invalid compatibility/i,
+      publish: /invalid compatibility/i,
+      verified: /invalid compatibility/i,
+    });
+  });
+
+  /*
+   * App Platforms
+   */
+
+  it('`platforms` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      platforms: undefined,
+    });
+
+    await assertValidates(app, {
+      debug: true, // platforms is optional for debug
+      publish: true, // platforms is optional for publish
+      verified: /should have required property 'platforms'/i,
+    });
+  });
+
+  it('`platforms` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      platforms: ['none'],
+    });
+
+    await assertValidates(app, {
+      debug: /platforms\[0\] should be equal to one of the allowed values/i,
+      publish: /platforms\[0\] should be equal to one of the allowed values/i,
+      verified: /platforms\[0\] should be equal to one of the allowed values/i,
+    });
+  });
+
+  /*
+   * App Category
+   */
+
+  it('`category` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      category: undefined,
+    });
+
+    await assertValidates(app, {
+      debug: true, // category is optional for debug
+      publish: /should have required property 'category'/i,
+      verified: /should have required property 'category'/i,
+    });
+  });
+
+  it('`category` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      category: ['none'],
+    });
+
+    await assertValidates(app, {
+      debug: /invalid category/i,
+      publish: /invalid category/i,
+      verified: /invalid category/i,
+    });
+  });
+
+  /*
+   * App Tags
+   */
+
+  it('`tags` can be validated', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      tags: { en: ['test'] },
+    });
+
+    await assertValidates(app, {
+      debug: true,
+      publish: true,
+      verified: true,
+    });
+  });
+
+  it('`tags` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      tags: 'test',
+    });
+
+    await assertValidates(app, {
+      debug: /tags should be object/i,
+      publish: /tags should be object/i,
+      verified: /tags should be object/i,
+    });
+  });
+
+  /*
+   * App Images
+   */
+
+  it('`images` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      images: undefined,
+    });
+
+    await assertValidates(app, {
+      debug: true, // debug does not validate images
+      publish: /should have required property 'images'/i,
+      verified: /should have required property 'images'/i,
+    });
+  });
+
+  it('`images` need to be a known format', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      images: {
+        small: '/assets/images/small.webp',
+        large: '/assets/images/large.webp',
+        xlarge: '/assets/images/xlarge.webp',
+      },
+    });
+
+    await assertValidates(app, {
+      debug: true, // debug does not validate images
+      publish: /invalid image extention/i,
+      verified: /invalid image extention/i,
+    });
+  });
+
+  /*
+   * App Author
+   */
+
+  it('`author` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      author: undefined,
+    });
+
+    await assertValidates(app, {
+      debug: /should have required property 'author'/i,
+      publish: /should have required property 'author'/i,
+      verified: /should have required property 'author'/i,
+    });
+  });
+
+  it('`author.name` should be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      author: {
+        name: undefined,
+      },
+    });
+
+    await assertValidates(app, {
+      debug: /author should have required property 'name'/i,
+      publish: /author should have required property 'name'/i,
+      verified: /author should have required property 'name'/i,
+    });
+  });
+
+  it('`author.email` should be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      author: {
+        name: 'Athom B.V.',
+        email: 10,
+      },
+    });
+
+    await assertValidates(app, {
+      debug: /author\.email should be string/i,
+      publish: /author\.email should be string/i,
+      verified: /author\.email should be string/i,
+    });
+  });
+
+  it('`author.website` should be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      author: {
+        name: 'Athom B.V.',
+        website: 10,
+      },
+    });
+
+    await assertValidates(app, {
+      debug: /author\.website should be string/i,
+      publish: /author\.website should be string/i,
+      verified: /author\.website should be string/i,
+    });
+  });
+
+  /*
+   * App Support
+   */
+
+  it('`support` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      support: undefined,
+    });
+
+    await assertValidates(app, {
+      debug: true, // support is optional for debug
+      publish: true, // support is optional for publish
+      verified: /should have required property 'support'/i,
+    });
+  });
+
+  it('`support` needs to be a valid link', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      support: 'test',
+    });
+
+    await assertValidates(app, {
+      debug: /support should match pattern/i,
+      publish: /support should match pattern/i,
+      verified: /support should match pattern/i,
+    });
+  });
+
+  /*
+   * App Permissions
+   */
+
+  it('`permissions` can be validated', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      permissions: ['homey:wireless:ble', 'homey:app:com.athom.example'],
+    });
+
+    await assertValidates(app, {
+      debug: true,
+      publish: true,
+      verified: true,
+    });
+  });
+
+  it('`permissions` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      permissions: ['none'],
+    });
+
+    await assertValidates(app, {
+      debug: /invalid permission/i,
+      publish: /invalid permission/i,
+      verified: /invalid permission/i,
+    });
+  });
+
+  /*
+   * App Source
+   */
+
+  it('`source` can be validated', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      source: 'https://github.com/athombv/com.athom.myapp',
+    });
+
+    await assertValidates(app, {
+      debug: true,
+      publish: true,
+      verified: true,
+    });
+  });
+
+  it('`source` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      source: 'test',
+    });
+
+    await assertValidates(app, {
+      debug: /source should match pattern/i,
+      publish: /source should match pattern/i,
+      verified: /source should match pattern/i,
+    });
+  });
+
+  /*
+   * App Home Page
+   */
+
+  it('`homepage` can be validated', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      homepage: 'https://homey.app/',
+    });
+
+    await assertValidates(app, {
+      debug: true,
+      publish: true,
+      verified: true,
+    });
+  });
+
+  it('`homepage` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      homepage: 'test',
+    });
+
+    await assertValidates(app, {
+      debug: /homepage should match pattern/i,
+      publish: /homepage should match pattern/i,
+      verified: /homepage should match pattern/i,
+    });
+  });
+
+  /*
+   * App Bugs
+   */
+
+  it('`bugs` can be validated', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      bugs: {
+        url: 'https://github.com/athombv/homey-apps-sdk-issues/issues',
+      },
+    });
+
+    await assertValidates(app, {
+      debug: true,
+      publish: true,
+      verified: true,
+    });
+  });
+
+  it('`bugs` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      bugs: 'test',
+    });
+
+    await assertValidates(app, {
+      debug: /bugs should be object/i,
+      publish: /bugs should be object/i,
+      verified: /bugs should be object/i,
+    });
+  });
+
+  /*
+   * App Athom Forum Discussion ID
+   */
+
+  it('`athomForumDiscussionId` can be validated', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      athomForumDiscussionId: 1234,
+    });
+
+    await assertValidates(app, {
+      debug: true,
+      publish: true,
+      verified: true,
+    });
+  });
+
+  it('`athomForumDiscussionId` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      athomForumDiscussionId: 'test',
+    });
+
+    await assertValidates(app, {
+      debug: /athomForumDiscussionId should be number/i,
+      publish: /athomForumDiscussionId should be number/i,
+      verified: /athomForumDiscussionId should be number/i,
+    });
+  });
+
+  /*
+   * App Homey Community Topic ID
+   */
+
+  it('`homeyCommunityTopicId` can be validated', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      homeyCommunityTopicId: 1234,
+    });
+
+    await assertValidates(app, {
+      debug: true,
+      publish: true,
+      verified: true,
+    });
+  });
+
+  it('`homeyCommunityTopicId` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      homeyCommunityTopicId: 'test',
+    });
+
+    await assertValidates(app, {
+      debug: /homeyCommunityTopicId should be number/i,
+      publish: /homeyCommunityTopicId should be number/i,
+      verified: /homeyCommunityTopicId should be number/i,
+    });
+  });
+
+  /*
+   * App Homey Community Topic ID
+   */
+
+  it('`contributers` can be validated', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      contributors: {
+        developers: [{
+          name: 'Athom B.V.',
+          email: 'info@athom.com',
+          website: 'https://athom.nl',
+        }],
+        translators: [{
+          name: 'Athom B.V.',
+          email: 'info@athom.com',
+          website: 'https://athom.nl',
+        }],
+      },
+    });
+
+    await assertValidates(app, {
+      debug: true,
+      publish: true,
+      verified: true,
+    });
+  });
+
+  it('`contributers` cannot contain additional properties', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      contributors: {
+        test: {},
+      },
+    });
+
+    await assertValidates(app, {
+      debug: /contributors should not have additional properties/i,
+      publish: /contributors should not have additional properties/i,
+      verified: /contributors should not have additional properties/i,
+    });
+  });
+
+  it('`contributers.developers` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      contributors: {
+        developers: {},
+      },
+    });
+
+    await assertValidates(app, {
+      debug: /contributors\['developers'\] should be array/i,
+      publish: /contributors\['developers'\] should be array/i,
+      verified: /contributors\['developers'\] should be array/i,
+    });
+  });
+
+  it('`contributers.translators` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      contributors: {
+        translators: {},
+      },
+    });
+
+    await assertValidates(app, {
+      debug: /contributors\['translators'\] should be array/i,
+      publish: /contributors\['translators'\] should be array/i,
+      verified: /contributors\['translators'\] should be array/i,
+    });
+  });
+});

--- a/test/validate-driver-manifest.js
+++ b/test/validate-driver-manifest.js
@@ -1,0 +1,251 @@
+/* eslint-disable node/no-unpublished-require */
+
+'use strict';
+
+const {
+  mockApp,
+  clearMockApp,
+  assertValidates,
+  baseAppManifest,
+  baseDriverManifest,
+} = require('./fixtures/mock-app');
+
+describe('HomeyLib.App#validate() driver manifest', function() {
+  this.slow(500);
+
+  afterEach(function() {
+    clearMockApp();
+  });
+
+  /*
+   * Driver ID
+   */
+
+  it('`id` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        id: undefined,
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /should have required property 'id'/i,
+      publish: /should have required property 'id'/i,
+      verified: /should have required property 'id'/i,
+    });
+  });
+
+  /*
+   * Driver Capabilities
+   */
+
+  it('`capabilities` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        capabilities: undefined,
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /should have required property 'capabilities'/i,
+      publish: /should have required property 'capabilities'/i,
+      verified: /should have required property 'capabilities'/i,
+    });
+  });
+
+  it('`capabilities` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        capabilities: ['test'],
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /drivers\.test invalid capability/i,
+      publish: /drivers\.test invalid capability/i,
+      verified: /drivers\.test invalid capability/i,
+    });
+  });
+
+  it('`capabilities` needs to be valid (with sub-capabilities)', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        capabilities: ['test.one'],
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /drivers\.test invalid capability/i,
+      publish: /drivers\.test invalid capability/i,
+      verified: /drivers\.test invalid capability/i,
+    });
+  });
+
+  it('`capabilities` custom capabilities are validated', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        capabilities: ['test'],
+      }],
+      capabilities: {
+        test: {
+          type: 'boolean',
+          title: 'Test capability',
+          getable: true,
+          setable: true,
+        },
+      },
+    });
+
+    await assertValidates(app, {
+      debug: true,
+      publish: true,
+      verified: true,
+    });
+  });
+
+  it('`capabilities` custom sub-capabilities are validated', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        capabilities: ['test.one', 'test.two'],
+      }],
+      capabilities: {
+        test: {
+          type: 'boolean',
+          title: 'Test capability',
+          getable: true,
+          setable: true,
+        },
+      },
+    });
+
+    await assertValidates(app, {
+      debug: true,
+      publish: true,
+      verified: true,
+    });
+  });
+
+  /*
+   * Driver Images
+   */
+
+  it('`images` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        images: undefined,
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: true, // debug does not validate images
+      publish: /should have required property 'images'/i,
+      verified: /should have required property 'images'/i,
+    });
+  });
+
+  it('`images` need to be a known format', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        images: {
+          small: '/assets/images/small.webp',
+          large: '/assets/images/large.webp',
+          xlarge: '/assets/images/xlarge.webp',
+        },
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: true, // debug does not validate images
+      publish: /invalid image extention/i,
+      verified: /invalid image extention/i,
+    });
+  });
+
+  /*
+   * Driver Platforms
+   */
+
+  it('`platforms` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        platforms: undefined,
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: true, // platforms is optional for debug, but will warn
+      publish: true, // platforms is optional for publish, but will warn
+      verified: /should have required property 'platforms'/i,
+    });
+  });
+
+  it('`platforms` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        platforms: ['none'],
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /platforms\[0\] should be equal to one of the allowed values/i,
+      publish: /platforms\[0\] should be equal to one of the allowed values/i,
+      verified: /platforms\[0\] should be equal to one of the allowed values/i,
+    });
+  });
+
+  /*
+   * Driver Connectivity
+   */
+
+  it('`connectivity` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        connectivity: undefined,
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: true, // connectivity is optional for debug
+      publish: true, // connectivity is optional for publish
+      verified: /should have required property 'connectivity'/i,
+    });
+  });
+
+  it('`connectivity` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        connectivity: ['none'],
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /connectivity\[0\] should be equal to one of the allowed values/i,
+      publish: /connectivity\[0\] should be equal to one of the allowed values/i,
+      verified: /connectivity\[0\] should be equal to one of the allowed values/i,
+    });
+  });
+});

--- a/test/validate-files.js
+++ b/test/validate-files.js
@@ -1,0 +1,267 @@
+/* eslint-disable node/no-unpublished-require */
+
+'use strict';
+
+const {
+  mockApp,
+  clearMockApp,
+  assertValidates,
+  createFakePng,
+  baseAppManifest,
+  baseDriverManifest,
+} = require('./fixtures/mock-app');
+
+const HomeyLib = require('..');
+
+describe('HomeyLib.App#validate() files', function() {
+  this.slow(500);
+
+  afterEach(function() {
+    clearMockApp();
+  });
+
+  it('can validate a minimal app manifest for debug', async function() {
+    const app = mockApp({
+      id: 'test.app',
+      name: { en: 'Test' },
+      version: '1.0.0',
+      sdk: 3,
+      compatibility: '>=5.0.0',
+      author: {
+        name: 'Athom B.V.',
+        email: 'info@athom.com',
+      },
+    });
+
+    await assertValidates(app, {
+      debug: true,
+      publish: /should have required property/i,
+      verified: /should have required property/i,
+    });
+  });
+
+  it('can validate a minimal app manifest for publish', async function() {
+    const app = mockApp({
+      id: 'test.app',
+      name: { en: 'Test' },
+      // description: { en: 'Test app' }, // TODO: should this be required?
+      brandColor: '#000000',
+      version: '1.0.0',
+      sdk: 3,
+      compatibility: '>=5.0.0',
+      category: ['tools'],
+      images: {
+        small: '/assets/images/small.png',
+        large: '/assets/images/large.png',
+        xlarge: '/assets/images/xlarge.png',
+      },
+      author: {
+        name: 'Athom B.V.',
+        email: 'info@athom.com',
+      },
+    });
+
+    await assertValidates(app, {
+      debug: true,
+      publish: true,
+      verified: /should have required property/i,
+    });
+  });
+
+  it('can validate a minimal app manifest for verified', async function() {
+    const app = mockApp({
+      id: 'test.app',
+      name: { en: 'Test' },
+      // description: { en: 'Test app' }, // TODO: should this be required?
+      brandColor: '#000000',
+      version: '1.0.0',
+      sdk: 3,
+      compatibility: '>=5.0.0',
+      platforms: ['local', 'cloud'],
+      category: ['tools'],
+      images: {
+        small: '/assets/images/small.png',
+        large: '/assets/images/large.png',
+        xlarge: '/assets/images/xlarge.png',
+      },
+      author: {
+        name: 'Athom B.V.',
+        email: 'info@athom.com',
+      },
+      support: 'mailto:support@homey.app',
+    });
+
+    await assertValidates(app, {
+      debug: true,
+      publish: true,
+      verified: true,
+    });
+  });
+
+  /*
+   * App Icon
+   */
+
+  it('assets/icon.svg needs to exist', async function() {
+    const app = mockApp(baseAppManifest, {
+      files: {
+        'assets.icon\\.svg': undefined,
+      },
+    });
+
+    await assertValidates(app, {
+      debug: /filepath does not exist/i,
+      publish: /filepath does not exist/i,
+      verified: /filepath does not exist/i,
+    });
+  });
+
+  /*
+   * App Images
+   */
+
+  it('/assets/images/*.png should be valid images', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      images: {
+        small: '/assets/images/small.png',
+        large: '/assets/images/large.png',
+        xlarge: '/assets/images/xlarge.png',
+      },
+    }, {
+      files: {
+        'assets.images.small\\.png': undefined,
+        'assets.images.large\\.png': undefined,
+        'assets.images.xlarge\\.png': undefined,
+      },
+    });
+
+    await assertValidates(app, {
+      debug: true, // debug does not validate images
+      publish: /filepath does not exist/i,
+      verified: /filepath does not exist/i,
+    });
+  });
+
+  it('/assets/images/*.png should have the correct size', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      images: {
+        small: '/assets/images/small.png',
+        large: '/assets/images/large.png',
+        xlarge: '/assets/images/xlarge.png',
+      },
+    }, {
+      files: {
+        'assets.images.small\\.png': createFakePng({ width: 0, height: 0 }),
+        'assets.images.large\\.png': createFakePng({ width: 0, height: 0 }),
+        'assets.images.xlarge\\.png': createFakePng({ width: 0, height: 0 }),
+      },
+    });
+
+    await assertValidates(app, {
+      debug: true, // debug does not validate images
+      publish: /invalid image size/i,
+      verified: /invalid image size/i,
+    });
+  });
+
+  /*
+   * Driver Images
+   */
+
+  it('drivers/test/assets/images/*.png should be valid images', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        images: {
+          small: 'drivers/test/assets/images/small.png',
+          large: 'drivers/test/assets/images/large.png',
+          xlarge: 'drivers/test/assets/images/xlarge.png',
+        },
+      }],
+    }, {
+      files: {
+        'drivers.test.assets.images.small\\.png': undefined,
+        'drivers.test.assets.images.large\\.png': undefined,
+        'drivers.test.assets.images.xlarge\\.png': undefined,
+      },
+    });
+
+    await assertValidates(app, {
+      debug: true, // debug does not validate images
+      publish: /filepath does not exist/i,
+      verified: /filepath does not exist/i,
+    });
+  });
+
+  it('drivers/test/assets/images/*.png should have the correct size', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        images: {
+          small: 'drivers/test/assets/images/small.png',
+          large: 'drivers/test/assets/images/large.png',
+          xlarge: 'drivers/test/assets/images/xlarge.png',
+        },
+      }],
+    }, {
+      files: {
+        'drivers.test.assets.images.small\\.png': createFakePng({ width: 0, height: 0 }),
+        'drivers.test.assets.images.large\\.png': createFakePng({ width: 0, height: 0 }),
+        'drivers.test.assets.images.xlarge\\.png': createFakePng({ width: 0, height: 0 }),
+      },
+    });
+
+    await assertValidates(app, {
+      debug: true, // debug does not validate images
+      publish: /invalid image size/i,
+      verified: /invalid image size/i,
+    });
+  });
+
+  /*
+   * App Env
+   */
+
+  it('/env.json can only contain uppercase properties', async function() {
+    const app = mockApp(baseAppManifest, {
+      env: { test: 'abc' },
+    });
+
+    await assertValidates(app, {
+      debug: /invalid \/env\.json key/i,
+      publish: /invalid \/env\.json key/i,
+      verified: /invalid \/env\.json key/i,
+    });
+  });
+
+  it('env.json can only contain string values', async function() {
+    const app = mockApp(baseAppManifest, {
+      env: { TEST: 1 },
+    });
+
+    await assertValidates(app, {
+      debug: /invalid \/env\.json value/i,
+      publish: /invalid \/env\.json value/i,
+      verified: /invalid \/env\.json value/i,
+    });
+  });
+
+  /*
+   * Test Test Cleanup
+   */
+
+  it('fails when an app does not exist', async function() {
+    // This tests that the mock is reset correctly (that makes sure our other tests are reliable)
+    const app = new HomeyLib.App('test_app');
+
+    await assertValidates(app, {
+      debug: false,
+      publish: false,
+      verified: false,
+    });
+  });
+});

--- a/test/validate-files.js
+++ b/test/validate-files.js
@@ -259,9 +259,9 @@ describe('HomeyLib.App#validate() files', function() {
     const app = new HomeyLib.App('test_app');
 
     await assertValidates(app, {
-      debug: false,
-      publish: false,
-      verified: false,
+      debug: /no such file or directory/i,
+      publish: /no such file or directory/i,
+      verified: /no such file or directory/i,
     });
   });
 });


### PR DESCRIPTION
This PR adds a test suite to `homey-lib`. This currently consists of 66 passing tests.
Each of these tests generates a variation of an app with a different manifest (and different files on a "virtual"/"mock" filesystem). We then assert that an app has a certain validation error (or is valid) at all the validation levels.

So, currently, running all tests calls `HomeyLib.App#validate()` ~190 times. This takes about 10s to run in parallel, and about 15s sequentially.

Because creating all testcases is quite a bit of work not everything is tested, I chose to completely test the "base manifest" and some interesting properties of the "driver manifest" so we can use these tests to verify https://github.com/athombv/node-homey-lib/pull/329.

It might also be interesting to test some actual complete app manifests from live apps. For example could add `fixtures/com.fibaro-example/` that only contains the `app.json` and various assets.
However this becomes tricky due to the number of driver folders with assets that we'd need to put in place. Alternatively we can use `mock-fs` for that too but then I don't think it is testing anything useful in addition to the other tests.

~We could also add an Action to run these test, I'm not very familiar with actions so I'll defer that to someone else.~ Added workflow with some help from Robin.
