### PR TITLE
fix: card validation incomplete

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -605,7 +605,7 @@ class App {
 
     const firstDeviceArgument = card.args.find(argument => {
       const filter = new URLSearchParams(argument.filter);
-      return argument.type === 'device' && (filter.has('driver_id') || filter.has('driverId'));
+      return argument.type === 'device' && (filter.has('driver_id') || filter.has('driverId') || filter.has('class') || filter.has('capabilities'));
     });
 
     // Filter to valid arguments for flow card titles


### PR DESCRIPTION
Right now people will get a warning on the following card that they need to add `[[device]]` to `titleFormatted`.

```
{
  "title": {
    "en": "Action with device argument and filter capabilities"
  },
  "titleFormatted": {
    "en": "Action with device argument and filter capabilities"
  },
  "hint": {
    "en": "Action with device argument and filter"
  },
  "args": [
    {
      "type": "device",
      "name": "device",
      "title": { "en": "Device" },
      "placeholder": { "en": "Device Placeholder" },
      "filter": "capabilities=onoff"
    }
  ]
}
```

Internally these cards are added to all app drivers and filtered per device so they are device cards and dont require `titleFormatted` properties for `type === 'device'` if it's the first argument. 