### PR TITLE
Make sure to close file descriptor after use

### DIFF
--- a/helpers/index.js
+++ b/helpers/index.js
@@ -10,6 +10,7 @@ try {
 
   if (fs && util && util.promisify) {
     module.exports.openAsync = util.promisify(fs.open);
+    module.exports.closeAsync = util.promisify(fs.close);
     module.exports.readAsync = util.promisify(fs.read);
     module.exports.statAsync = util.promisify(fs.stat);
     module.exports.readFileAsync = util.promisify(fs.readFile);

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -16,6 +16,7 @@ const Energy = require('../Energy');
 
 const {
   openAsync,
+  closeAsync,
   readAsync,
   statAsync,
   readFileAsync,
@@ -709,6 +710,7 @@ class App {
     const fd = await openAsync(filepath, 'r');
     const buffer = Buffer.alloc(numBytes);
     await readAsync(fd, buffer, 0, numBytes, 0);
+    await closeAsync(fd);
     return buffer;
   }
 


### PR DESCRIPTION
This fixes permission issues with images during `homey publish` since `homey` 2.33.5.