### PR TITLE
feat(zigbee): add validation

### DIFF
--- a/assets/app/schema.json
+++ b/assets/app/schema.json
@@ -747,6 +747,78 @@
         ]
       }
     },
+    "zigbeeDevice": {
+      "type": "object",
+      "required": [ 
+        "manufacturerName", "productId", "endpoints"
+      ],
+      "properties": {
+        "manufacturerName": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "productId": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "endpoints": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "[0-255]": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "clusters": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  }
+                },
+                "bindings": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "learnmode": {
+          "type": "object",
+          "required": [
+            "instruction"
+          ],
+          "properties": {
+            "image": {
+              "type": "string"
+            },
+            "instruction": {
+              "$ref": "#/definitions/i18nObject"
+            }
+          }
+        }
+      }
+    },
     "zwaveDevice": {
       "type": "object",
       "required": [
@@ -1242,7 +1314,7 @@
             "$ref": "#/definitions/zwaveDevice"
           },
           "zigbee": {
-            "type": "object"
+            "$ref": "#/definitions/zigbeeDevice"
           },
           "rf433": {
             "type": "object",

--- a/test/validate-driver-manifest.js
+++ b/test/validate-driver-manifest.js
@@ -332,7 +332,7 @@ describe('HomeyLib.App#validate() driver manifest', function() {
       }],
     });
 
-    // Product ID can be a string
+    // manufacturerName can be a string
     await assertValidates(app, {
       debug: /zigbee\.manufacturerName should be string/i,
       publish: /zigbee\.manufacturerName should be string/i,

--- a/test/validate-driver-manifest.js
+++ b/test/validate-driver-manifest.js
@@ -248,4 +248,281 @@ describe('HomeyLib.App#validate() driver manifest', function() {
       verified: /connectivity\[0\] should be equal to one of the allowed values/i,
     });
   });
+
+  /*
+   * Zigbee Driver
+   */
+
+  it('`zigbee.productId` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        zigbee: {
+          manufacturerName: ['dummyManufacturer'],
+          endpoints: {},
+        },
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /zigbee should have required property 'productId'/i,
+      publish: /zigbee should have required property 'productId'/i,
+      verified: /zigbee should have required property 'productId'/i,
+    });
+  });
+
+  it('`zigbee.productId` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        zigbee: {
+          productId: true,
+          manufacturerName: ['dummyManufacturer'],
+          endpoints: {},
+        },
+      }],
+    });
+
+    // Product ID can be a string
+    await assertValidates(app, {
+      debug: /zigbee\.productId should be string/i,
+      publish: /zigbee\.productId should be string/i,
+      verified: /zigbee\.productId should be string/i,
+    });
+
+    // or an array of strings
+    await assertValidates(app, {
+      debug: /zigbee\.productId should be array/i,
+      publish: /zigbee\.productId should be array/i,
+      verified: /zigbee\.productId should be array/i,
+    });
+  });
+
+  it('`zigbee.manufacturerName` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        zigbee: {
+          productId: ['dummyProduct'],
+          endpoints: {},
+        },
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /zigbee should have required property 'manufacturerName'/i,
+      publish: /zigbee should have required property 'manufacturerName'/i,
+      verified: /zigbee should have required property 'manufacturerName'/i,
+    });
+  });
+
+  it('`zigbee.manufacturerName` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        zigbee: {
+          productId: 'dummyProduct',
+          manufacturerName: true,
+          endpoints: {},
+        },
+      }],
+    });
+
+    // Product ID can be a string
+    await assertValidates(app, {
+      debug: /zigbee\.manufacturerName should be string/i,
+      publish: /zigbee\.manufacturerName should be string/i,
+      verified: /zigbee\.manufacturerName should be string/i,
+    });
+
+    // or an array of strings
+    await assertValidates(app, {
+      debug: /zigbee\.manufacturerName should be array/i,
+      publish: /zigbee\.manufacturerName should be array/i,
+      verified: /zigbee\.manufacturerName should be array/i,
+    });
+  });
+
+  it('`zigbee.endpoints` needs to be defined', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        zigbee: {
+          productId: ['dummyProduct'],
+          manufacturerName: 'dummyManufacturer',
+        },
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /zigbee should have required property 'endpoints'/i,
+      publish: /zigbee should have required property 'endpoints'/i,
+      verified: /zigbee should have required property 'endpoints'/i,
+    });
+  });
+
+  it('`zigbee.endpoints` needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        zigbee: {
+          productId: ['dummyProduct'],
+          manufacturerName: ['dummyManufacturer'],
+          endpoints: true,
+        },
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /zigbee\.endpoints should be object/i,
+      publish: /zigbee\.endpoints should be object/i,
+      verified: /zigbee\.endpoints should be object/i,
+    });
+  });
+
+  it('`zigbee.endpoints` key needs to be valid', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        zigbee: {
+          productId: ['dummyProduct'],
+          manufacturerName: ['dummyManufacturer'],
+          endpoints: {
+            bla: [],
+          },
+        },
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /zigbee\.endpoints should NOT have additional properties/i,
+      publish: /zigbee\.endpoints should NOT have additional properties/i,
+      verified: /zigbee\.endpoints should NOT have additional properties/i,
+    });
+  });
+
+  it('`zigbee.endpoints.x` needs to be an object', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        zigbee: {
+          productId: ['dummyProduct'],
+          manufacturerName: ['dummyManufacturer'],
+          endpoints: {
+            1: [],
+          },
+        },
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /zigbee\.endpoints\['1'] should be object/i,
+      publish: /zigbee\.endpoints\['1'] should be object/i,
+      verified: /zigbee\.endpoints\['1'] should be object/i,
+    });
+  });
+
+  it('`zigbee.endpoints.x.clusters` needs to be an array', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        zigbee: {
+          productId: ['dummyProduct'],
+          manufacturerName: ['dummyManufacturer'],
+          endpoints: {
+            1: {
+              clusters: {},
+            },
+          },
+        },
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /zigbee\.endpoints\['1'].clusters should be array/i,
+      publish: /zigbee\.endpoints\['1'].clusters should be array/i,
+      verified: /zigbee\.endpoints\['1'].clusters should be array/i,
+    });
+  });
+
+  it('`zigbee.endpoints.x.clusters` needs to be an array of only numbers', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        zigbee: {
+          productId: ['dummyProduct'],
+          manufacturerName: ['dummyManufacturer'],
+          endpoints: {
+            1: {
+              clusters: [true],
+            },
+          },
+        },
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /zigbee\.endpoints\['1'].clusters\[0] should be number/i,
+      publish: /zigbee\.endpoints\['1'].clusters\[0] should be number/i,
+      verified: /zigbee\.endpoints\['1'].clusters\[0] should be number/i,
+    });
+  });
+
+  it('`zigbee.endpoints.x.bindings` needs to be an array', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        zigbee: {
+          productId: ['dummyProduct'],
+          manufacturerName: ['dummyManufacturer'],
+          endpoints: {
+            1: {
+              bindings: {},
+            },
+          },
+        },
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /zigbee\.endpoints\['1'].bindings should be array/i,
+      publish: /zigbee\.endpoints\['1'].bindings should be array/i,
+      verified: /zigbee\.endpoints\['1'].bindings should be array/i,
+    });
+  });
+
+  it('`zigbee.endpoints.x.bindings` needs to be an array of only numbers', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        zigbee: {
+          productId: ['dummyProduct'],
+          manufacturerName: ['dummyManufacturer'],
+          endpoints: {
+            1: {
+              bindings: [true],
+            },
+          },
+        },
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /zigbee\.endpoints\['1'].bindings\[0] should be number/i,
+      publish: /zigbee\.endpoints\['1'].bindings\[0] should be number/i,
+      verified: /zigbee\.endpoints\['1'].bindings\[0] should be number/i,
+    });
+  });
 });


### PR DESCRIPTION
Validate that the `zigbee` object in a driver has the following shape:

```json
  "zigbee": {
    "manufacturerName": "manufName", // or array of strings
    "productId": [ // or just a string
      "productX"
    ],
    "endpoints": {
      "1": {
        "clusters": [
          0
        ],
        "bindings": []
      }
    },
    "learnmode": {
      "image": "/drivers/product_x/assets/learnmode.svg",
      "instruction": {
        "en": "Instruction"
      }
    }
  }
```