### PR TITLE
fix(validation): improve image validation error message

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -568,7 +568,7 @@ class App {
       const extension = extname(imagePath);
 
       if (typeof IMAGE_MARKERS[extension] === 'undefined') {
-        throw new Error(`Invalid image extension: ${extension}`);
+        throw new Error(`Invalid image extension (${extension})${ errorPath ? ` ${errorPath}.${size}` : ''}: ${join(this._path, imagePath)}`);
       }
 
       await this._ensureFileExistsCaseSensitive(imagePath);
@@ -577,7 +577,7 @@ class App {
       const imageBytes = await this._readBytes(imagePath, compareBuffer.length);
 
       if (!imageBytes.equals(compareBuffer)) {
-        throw new Error(`Invalid image: ${imagePath}`);
+        throw new Error(`Invalid image${ errorPath ? ` ${errorPath}.${size}` : ''}: ${join(this._path, imagePath)}`);
       }
 
       const requiredSize = IMAGE_SIZES[type][size];

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -298,7 +298,7 @@ class App {
           if (!driver.images) {
             throw new Error(`drivers.${driver.id}: property \`images\` is required in order to publish an app.`);
           }
-          await this._validateImages(driver.images, 'driver');
+          await this._validateImages(driver.images, 'driver', `drivers.${driver.id}`);
         }
 
         if (levelVerified) {
@@ -560,7 +560,7 @@ class App {
     }
   }
 
-  async _validateImages(imagesObj, type) {
+  async _validateImages(imagesObj, type, errorPath) {
     const sizes = ['small', 'large'];
     for (let i = 0; i < sizes.length; i++) {
       const size = sizes[i];
@@ -568,7 +568,7 @@ class App {
       const extension = extname(imagePath);
 
       if (typeof IMAGE_MARKERS[extension] === 'undefined') {
-        throw new Error(`Invalid image extention: ${extension}`);
+        throw new Error(`Invalid image extension: ${extension}`);
       }
 
       await this._ensureFileExistsCaseSensitive(imagePath);
@@ -584,7 +584,7 @@ class App {
       const imageSize = await imageSizeAsync(join(this._path, imagePath));
       if (imageSize.width !== requiredSize.width
         || imageSize.height !== requiredSize.height) {
-        throw new Error(`Invalid image size (${imageSize.width}x${imageSize.height}): ${imagePath}\nRequired: ${requiredSize.width}x${requiredSize.height}`);
+        throw new Error(`Invalid image size (${imageSize.width}x${imageSize.height})${ errorPath ? ` ${errorPath}.${size}` : ''}: ${join(this._path, imagePath)}\nRequired: ${requiredSize.width}x${requiredSize.height}`);
       }
     }
   }

--- a/test/validate-base-manifest.js
+++ b/test/validate-base-manifest.js
@@ -329,8 +329,8 @@ describe('HomeyLib.App#validate() base manifest', function() {
 
     await assertValidates(app, {
       debug: true, // debug does not validate images
-      publish: /invalid image extention/i,
-      verified: /invalid image extention/i,
+      publish: /invalid image extension/i,
+      verified: /invalid image extension/i,
     });
   });
 

--- a/test/validate-driver-manifest.js
+++ b/test/validate-driver-manifest.js
@@ -172,8 +172,8 @@ describe('HomeyLib.App#validate() driver manifest', function() {
 
     await assertValidates(app, {
       debug: true, // debug does not validate images
-      publish: /invalid image extention/i,
-      verified: /invalid image extention/i,
+      publish: /invalid image extension/i,
+      verified: /invalid image extension/i,
     });
   });
 


### PR DESCRIPTION
- Adds full path to checked images.
- Adds reference to which driver the error occurred for.

Before:
<img width="515" alt="Screenshot 2023-11-09 at 12 46 04" src="https://github.com/athombv/node-homey-lib/assets/5762579/4cb15a28-a05f-4f3f-8676-48e8b29cad05">

After:
<img width="1224" alt="Screenshot 2023-11-09 at 12 40 34" src="https://github.com/athombv/node-homey-lib/assets/5762579/82c08095-90ba-40a0-9a5b-3d47c9dfc257">
