### PR TITLE
Fix flow triggers for some new capabilities

### DIFF
--- a/assets/capability/capabilities/alarm_cleaning_pad_missing.json
+++ b/assets/capability/capabilities/alarm_cleaning_pad_missing.json
@@ -23,7 +23,7 @@
   "$flow": {
     "triggers": [
       {
-        "id": "alarm_pad_missing_true",
+        "id": "alarm_cleaning_pad_missing_true",
         "highlight": true,
         "title": {
           "en": "The cleaning pad was removed",
@@ -31,7 +31,7 @@
         }
       },
       {
-        "id": "alarm_pad_missing_false",
+        "id": "alarm_cleaning_pad_missing_false",
         "title": {
           "en": "The cleaning pad was placed",
           "nl": "Het reinigingspad is geplaatst"
@@ -40,7 +40,7 @@
     ],
     "conditions": [
       {
-        "id": "alarm_pad_missing",
+        "id": "alarm_cleaning_pad_missing",
         "title": {
           "en": "The cleaning pad is !{{missing|present}}",
           "nl": "Het reigningingspad is !{{aanwezig|afwezig}}"

--- a/assets/capability/capabilities/alarm_door_fault.json
+++ b/assets/capability/capabilities/alarm_door_fault.json
@@ -23,7 +23,7 @@
   "$flow": {
     "triggers": [
       {
-        "id": "alarm_door_true",
+        "id": "alarm_door_fault_true",
         "highlight": true,
         "title": {
           "en": "The door alarm turned on",
@@ -31,7 +31,7 @@
         }
       },
       {
-        "id": "alarm_door_false",
+        "id": "alarm_door_fault_false",
         "title": {
           "en": "The door alarm turned off",
           "nl": "Het deur-alarm ging uit"

--- a/assets/capability/capabilities/measure_hepa_filter.json
+++ b/assets/capability/capabilities/measure_hepa_filter.json
@@ -18,7 +18,7 @@
   "$flow": {
     "triggers": [
       {
-        "id": "hepa_filter_changed",
+        "id": "measure_hepa_filter_changed",
         "highlight": true,
         "title": {
           "en": "The HEPA filter level changed to",

--- a/assets/capability/capabilities/mower_state.json
+++ b/assets/capability/capabilities/mower_state.json
@@ -39,7 +39,7 @@
   "$flow": {
     "triggers": [
       {
-        "id": "lawnmower_state_changed",
+        "id": "mower_state_changed",
         "title": {
           "en": "The lawnmower state changed"
         },

--- a/assets/capability/capabilities/target_humidity_max.json
+++ b/assets/capability/capabilities/target_humidity_max.json
@@ -23,7 +23,7 @@
   "$flow": {
     "triggers": [
       {
-        "id": "setpoint_humidity_max_changed",
+        "id": "target_humidity_max_changed",
         "title": {
           "en": "The maximum target humidity has changed",
           "nl": "De maximale doelvochtigheid is gewijzigd"

--- a/assets/capability/capabilities/target_humidity_min.json
+++ b/assets/capability/capabilities/target_humidity_min.json
@@ -23,7 +23,7 @@
   "$flow": {
     "triggers": [
       {
-        "id": "setpoint_humidity_min_changed",
+        "id": "target_humidity_min_changed",
         "title": {
           "en": "The minimum target humidity has changed",
           "nl": "De minimale doelvochtigheid is gewijzigd"

--- a/assets/capability/capabilities/target_temperature_max.json
+++ b/assets/capability/capabilities/target_temperature_max.json
@@ -23,7 +23,7 @@
   "$flow": {
     "triggers": [
       {
-        "id": "temperature_setpoint_max_changed",
+        "id": "target_temperature_max_changed",
         "title": {
           "en": "The maximum target temperature has changed",
           "nl": "De maximale doeltemperatuur is gewijzigd"

--- a/assets/capability/capabilities/target_temperature_min.json
+++ b/assets/capability/capabilities/target_temperature_min.json
@@ -23,7 +23,7 @@
   "$flow": {
     "triggers": [
       {
-        "id": "setpoint_temperature_min_changed",
+        "id": "target_temperature_min_changed",
         "title": {
           "en": "The minimum target temperature has changed",
           "nl": "De minimale doeltemperatuur is gewijzigd"


### PR DESCRIPTION
Flow triggers ending in `_true`, `_false` or `_checked` should start with the capability id.