### PR TITLE
fix(validate): allow `homeBattery` devices to not provide `batteries` array

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -310,7 +310,7 @@ class App {
 
           // validate battery
           if (BATTERY_CAPABILITIES.includes(capabilityId)) {
-            if (!driver.energy || !Array.isArray(driver.energy.batteries)) {
+            if ((!driver.energy || (!Array.isArray(driver.energy.batteries) && !driver.energy.homeBattery))) {
               if (levelPublish) {
                 throw new Error(`drivers.${driver.id} is missing an array 'energy.batteries' because the capability ${capabilityId} is being used.`);
               }


### PR DESCRIPTION
It doesn't make sense for home batteries to provide the type of built-in battery. It was intended for battery operated devices that should list the type of battery they use for easy replacement.