### PR TITLE
fix(driver): Add capability checks for energy settings warnings

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -491,21 +491,29 @@ class App {
             });
           }
 
-          if (driver.energy.cumulative === true) { 
+          const hasMeterPowerCapability = driver.capabilities.some(capability => Capability.isInstanceOfId(capability, 'meter_power'));
+
+          if (driver.energy.cumulative === true && hasMeterPowerCapability) {
             if (typeof driver.energy.cumulativeImportedCapability !== 'string') {
-              console.warn(`Warning: drivers.${driver.id} has energy.cumulative set to true, but is missing 'cumulativeImportedCapability'. Disregard this warning if the driver does not have \`meter_power\` capabilities.`);
+              console.warn(`Warning: drivers.${driver.id} has energy.cumulative set to true, but is missing 'cumulativeImportedCapability'.`);
             }
             if (typeof driver.energy.cumulativeExportedCapability !== 'string') {
-              console.warn(`Warning: drivers.${driver.id} has energy.cumulative set to true, but is missing 'cumulativeExportedCapability'. Disregard this warning if the driver does not have \`meter_power\` capabilities.`);
+              console.warn(`Warning: drivers.${driver.id} has energy.cumulative set to true, but is missing 'cumulativeExportedCapability'.`);
             }
           }
 
-          if (driver.energy.homeBattery === true) { 
+          if (driver.energy.homeBattery === true && hasMeterPowerCapability) { 
             if (typeof driver.energy.meterPowerImportedCapability !== 'string') {
               console.warn(`Warning: drivers.${driver.id} has energy.homeBattery set to true, but is missing 'meterPowerImportedCapability'.`);
             }
             if (typeof driver.energy.meterPowerExportedCapability !== 'string') {
               console.warn(`Warning: drivers.${driver.id} has energy.homeBattery set to true, but is missing 'meterPowerExportedCapability'.`);
+            }
+          }
+
+          if (driver.energy.evCharger === true && hasMeterPowerCapability) { 
+            if (typeof driver.energy.meterPowerImportedCapability !== 'string') {
+              console.warn(`Warning: drivers.${driver.id} has energy.evCharger set to true, but is missing 'meterPowerImportedCapability'.`);
             }
           }
 


### PR DESCRIPTION
Ensure that warnings for missing capabilities are only logged if the driver has the 'meter_power' capability when energy settings are enabled.