### PR TITLE
fix: check nested setting groups for private prefix use

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -60,6 +60,18 @@ const BATTERY_CAPABILITIES = [
   'alarm_battery',
 ];
 
+const RESERVED_SETTING_PREFIXES = new Set([
+  'homey:',
+  'zw_',
+  'zb_',
+  'mtr_',
+  'thread_',
+  'zone_',
+  'energy_',
+  'satellite_mode_',
+  'homekit_',
+])
+
 class App {
 
   constructor(path) {
@@ -355,47 +367,9 @@ class App {
           }
         }
 
-      
-        const reservedPrefixes = new Set([
-          'homey:',
-          'zw_',
-          'zb_',
-          'mtr_',
-          'thread_',
-          'zone_',
-          'energy_',
-          'satellite_mode_',
-          'homekit_',
-        ])
-
         if (Array.isArray(driver.settings)) {
           for (const setting of driver.settings) {
-            if (
-              setting.type &&
-              setting.type === "group" &&
-              setting.children &&
-              Array.isArray(setting.children)
-            ) {
-              for (const childSettings of setting.children) {
-                for (const prefix of reservedPrefixes) {
-                  if (childSettings.id.startsWith(prefix)) {
-                    console.warn(
-                      `drivers.${driver.id} invalid setting id: ${setting.id}, cannot start with reserved prefix: ${prefix}`
-                    );
-                    // throw new Error(`drivers.${driver.id} invalid setting id: ${setting.id}, cannot start with reserved prefix: ${prefix}`);
-                  }
-                }
-              }
-            } else {
-              for (const prefix of reservedPrefixes) {
-                if (setting.id.startsWith(prefix)) {
-                  console.warn(
-                    `drivers.${driver.id} invalid setting id: ${setting.id}, cannot start with reserved prefix: ${prefix}`
-                  );
-                  // throw new Error(`drivers.${driver.id} invalid setting id: ${setting.id}, cannot start with reserved prefix: ${prefix}`);
-                }
-              }
-            }
+            this._checkPrivateSettingPrefixUse(setting, driver);
           }
         }
 
@@ -725,6 +699,27 @@ class App {
     }
 
     this.debug('Validated successfully');
+  }
+
+  _checkPrivateSettingPrefixUse(setting, driver) {
+    if (
+      setting.type &&
+      setting.type === "group" &&
+      setting.children &&
+      Array.isArray(setting.children)
+    ) {
+      for (const childSetting of setting.children) {
+        this._checkPrivateSettingPrefixUse(childSetting, driver);
+      }
+    } else {
+      for (const prefix of RESERVED_SETTING_PREFIXES) {
+        if (setting.id.startsWith(prefix)) {
+          console.warn(
+            `drivers.${driver.id} invalid setting id: ${setting.id}, cannot start with reserved prefix: ${prefix}`
+          );
+        }
+      }
+    }
   }
 
   _checkZwaveForSetting(driver, setting) {


### PR DESCRIPTION
When checking for private prefix use in setting IDs, groups nested in another group were handled incorrectly:
If the group did not have an ID an error would occur due to calling .startsWith on undefined.
If the group did have an ID its children would not be checked for private prefix use.

I moved the check to a private method, which gets called recursively for child settings in groups.
Groups without IDs now no longer result in errors, and children with illegal prefixes result in a warning.