### PR TITLE
test: cover titleShort app capability validation

### DIFF
--- a/test/validate-driver-manifest.js
+++ b/test/validate-driver-manifest.js
@@ -121,6 +121,7 @@ describe('HomeyLib.App#validate() driver manifest', function() {
         test: {
           type: 'boolean',
           title: 'Test capability',
+          titleShort: 'Test',
           getable: true,
           setable: true,
         },


### PR DESCRIPTION
## Summary
- Adds regression coverage for custom app capabilities using `titleShort` in `app.json`.
- Confirms app validation accepts `titleShort` through the shared capability schema used by `Capability.validate()`.

## Notes
- No separate app validation code path was needed: `App.validate()` already validates `appJson.capabilities` by constructing a `Capability` and calling `validate()`.

## Test plan
- [x] `npx mocha test/validate-driver-manifest.js --grep "custom capabilities are validated"`
- [x] `npm test`