### PR TITLE
Require Homey 13.2.1 for capability titleShort

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -242,6 +242,14 @@ class App {
       throw new Error(`Invalid sdk (${appJson.sdk}), Python apps must use sdk version 3`);
     }
 
+    if (appJson.capabilities) {
+      for (const [capabilityId, capability] of Object.entries(appJson.capabilities)) {
+        if (capability.titleShort !== undefined && semver.lt(semver.minVersion(appJson.compatibility), '13.2.1')) {
+          throw new Error(`capabilities.${capabilityId}.titleShort requires a compatibility of at least >=13.2.1`);
+        }
+      }
+    }
+
     App.validatePythonVersion(appJson);
 
     // Validate that Python apps have cross-platform venvs
@@ -386,6 +394,10 @@ class App {
         // validate `appJson.drivers[].capabilitiesOptions`
         if (driver.capabilitiesOptions) {
           for (const [capabilityId, capabilityOptions] of Object.entries(driver.capabilitiesOptions)) {
+            if (capabilityOptions.titleShort !== undefined && semver.lt(semver.minVersion(appJson.compatibility), '13.2.1')) {
+              throw new Error(`drivers.${driver.id}.capabilitiesOptions.${capabilityId}.titleShort requires a compatibility of at least >=13.2.1`);
+            }
+
             // Validate target_power_mode values - require homey, at least one non-homey, no reserved prefixes
             if (Capability.isInstanceOfId(capabilityId, 'target_power_mode') && Array.isArray(capabilityOptions.values)) {
               const hasHomey = capabilityOptions.values.some(v => v && typeof v === 'object' && v.id === 'homey');

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -149,6 +149,8 @@ class App {
       throw new Error('Invalid compatibility');
     }
 
+    const appCompatibilityMinVersion = semver.minVersion(appJson.compatibility);
+
     if (appJson.esm === true && semver.lt(semver.coerce(appJson.compatibility), '12.0.1')) {
       throw new Error('ESM apps require a compatibility of at least >=12.0.1');
     }
@@ -220,19 +222,15 @@ class App {
 
     // validate sdk v3 apps have compatibility of at least >=5.0.0
     if (appJson.sdk === 3) {
-      // lowest version that satisfies the compatibility
-      const minVersion = semver.minVersion(appJson.compatibility);
-
       // lowest version must be greater than or equal to 5.0.0 for sdk v3 apps
-      if (!semver.gt(minVersion, '4.2.0')) {
+      if (!semver.gt(appCompatibilityMinVersion, '4.2.0')) {
         throw new Error(`Invalid compatibility (${appJson.compatibility}), SDK version 3 apps must have a compatibility of at least >=5.0.0`);
       }
     }
 
     // validate that Python apps target compatibility of at least >=13.0.0
     if (appJson.runtime === 'python') {
-      const minVersion = semver.minVersion(appJson.compatibility);
-      if (!semver.gte(minVersion, '13.0.0')) {
+      if (!semver.gte(appCompatibilityMinVersion, '13.0.0')) {
         throw new Error(`Invalid compatibility (${appJson.compatibility}), Python apps must have a compatibility of at least >=13.0.0`);
       }
     }
@@ -244,7 +242,7 @@ class App {
 
     if (appJson.capabilities) {
       for (const [capabilityId, capability] of Object.entries(appJson.capabilities)) {
-        if (capability.titleShort !== undefined && semver.lt(semver.minVersion(appJson.compatibility), '13.2.1')) {
+        if (capability.titleShort !== undefined && semver.lt(appCompatibilityMinVersion, '13.2.1')) {
           throw new Error(`capabilities.${capabilityId}.titleShort requires a compatibility of at least >=13.2.1`);
         }
       }
@@ -361,7 +359,7 @@ class App {
           throw new Error(`drivers.${driver.id} invalid driver class: ${driver.class}`);
         }
 
-        if (allowedClasses[driver.class].minCompatibility && semver.lt(semver.minVersion(appJson.compatibility), allowedClasses[driver.class].minCompatibility)) {
+        if (allowedClasses[driver.class].minCompatibility && semver.lt(appCompatibilityMinVersion, allowedClasses[driver.class].minCompatibility)) {
           // Compatibility must be greater than or equal to the minimum required compatibility
           throw new Error(`drivers.${driver.id} driver class: ${driver.class} is not available for compatibility ${appJson.compatibility}, requires minimum: ${allowedClasses[driver.class].minCompatibility}`);
         }
@@ -376,7 +374,7 @@ class App {
             throw new Error(`drivers.${driver.id} invalid capability: ${capability}`);
           }
 
-          if (isSystemCapability && !isAppCapability && allowedCapabilities[capabilityId].minCompatibility && semver.lt(semver.minVersion(appJson.compatibility), allowedCapabilities[capabilityId].minCompatibility)) {
+          if (isSystemCapability && !isAppCapability && allowedCapabilities[capabilityId].minCompatibility && semver.lt(appCompatibilityMinVersion, allowedCapabilities[capabilityId].minCompatibility)) {
             // Compatibility must be greater than or equal to the minimum required compatibility
             throw new Error(`drivers.${driver.id} capability: ${capabilityId} is not available for compatibility ${appJson.compatibility}, requires minimum: ${allowedCapabilities[capabilityId].minCompatibility}`);
           }
@@ -394,7 +392,11 @@ class App {
         // validate `appJson.drivers[].capabilitiesOptions`
         if (driver.capabilitiesOptions) {
           for (const [capabilityId, capabilityOptions] of Object.entries(driver.capabilitiesOptions)) {
-            if (capabilityOptions.titleShort !== undefined && semver.lt(semver.minVersion(appJson.compatibility), '13.2.1')) {
+            if (capabilityOptions === null || typeof capabilityOptions !== 'object' || Array.isArray(capabilityOptions)) {
+              throw new Error(`drivers.${driver.id}.capabilitiesOptions.${capabilityId} must be an object`);
+            }
+
+            if (capabilityOptions.titleShort !== undefined && semver.lt(appCompatibilityMinVersion, '13.2.1')) {
               throw new Error(`drivers.${driver.id}.capabilitiesOptions.${capabilityId}.titleShort requires a compatibility of at least >=13.2.1`);
             }
 

--- a/test/validate-driver-manifest.js
+++ b/test/validate-driver-manifest.js
@@ -183,6 +183,24 @@ describe('HomeyLib.App#validate() driver manifest', function() {
     });
   });
 
+  it('`capabilitiesOptions` entries need to be objects', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      drivers: [{
+        ...baseDriverManifest,
+        capabilitiesOptions: {
+          onoff: null,
+        },
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /drivers\.test\.capabilitiesOptions\.onoff must be an object/i,
+      publish: /drivers\.test\.capabilitiesOptions\.onoff must be an object/i,
+      verified: /drivers\.test\.capabilitiesOptions\.onoff must be an object/i,
+    });
+  });
+
   it('`capabilities` custom sub-capabilities are validated', async function() {
     const app = mockApp({
       ...baseAppManifest,

--- a/test/validate-driver-manifest.js
+++ b/test/validate-driver-manifest.js
@@ -113,6 +113,7 @@ describe('HomeyLib.App#validate() driver manifest', function() {
   it('`capabilities` custom capabilities are validated', async function() {
     const app = mockApp({
       ...baseAppManifest,
+      compatibility: '>=13.2.1',
       drivers: [{
         ...baseDriverManifest,
         capabilities: ['test'],
@@ -132,6 +133,53 @@ describe('HomeyLib.App#validate() driver manifest', function() {
       debug: true,
       publish: true,
       verified: true,
+    });
+  });
+
+  it('`capabilities` titleShort requires compatibility >=13.2.1', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      compatibility: '>=13.2.0',
+      drivers: [{
+        ...baseDriverManifest,
+        capabilities: ['test'],
+      }],
+      capabilities: {
+        test: {
+          type: 'boolean',
+          title: 'Test capability',
+          titleShort: 'Test',
+          getable: true,
+          setable: true,
+        },
+      },
+    });
+
+    await assertValidates(app, {
+      debug: /capabilities\.test\.titleShort requires a compatibility of at least >=13\.2\.1/i,
+      publish: /capabilities\.test\.titleShort requires a compatibility of at least >=13\.2\.1/i,
+      verified: /capabilities\.test\.titleShort requires a compatibility of at least >=13\.2\.1/i,
+    });
+  });
+
+  it('`capabilitiesOptions` titleShort requires compatibility >=13.2.1', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      compatibility: '>=13.2.0',
+      drivers: [{
+        ...baseDriverManifest,
+        capabilitiesOptions: {
+          onoff: {
+            titleShort: { en: 'Power' },
+          },
+        },
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /drivers\.test\.capabilitiesOptions\.onoff\.titleShort requires a compatibility of at least >=13\.2\.1/i,
+      publish: /drivers\.test\.capabilitiesOptions\.onoff\.titleShort requires a compatibility of at least >=13\.2\.1/i,
+      verified: /drivers\.test\.capabilitiesOptions\.onoff\.titleShort requires a compatibility of at least >=13\.2\.1/i,
     });
   });
 


### PR DESCRIPTION
Adds validation for capability `titleShort` so apps only use it when their Homey compatibility supports it.

Summary:
- Reject custom app capabilities with `titleShort` when `compatibility` is below `>=13.2.1`.
- Apply the same compatibility gate to driver `capabilitiesOptions.<capabilityId>.titleShort` overrides.
- Cover both cases in the driver manifest validation tests.

Validation:
- `npm test -- test/validate-driver-manifest.js`
- `node --check lib/App/index.js`
- `node --check test/validate-driver-manifest.js`