### PR TITLE
Fix capability title capitalisation and French translation

### DIFF
--- a/assets/capability/capabilities/fan_speed.json
+++ b/assets/capability/capabilities/fan_speed.json
@@ -1,7 +1,7 @@
 {
   "type": "number",
   "title": {
-    "en": "Fan Speed",
+    "en": "Fan speed",
     "nl": "Ventilatorsnelheid",
     "da": "Ventilatorhastighed",
     "it": "Velocità della ventola",

--- a/assets/capability/capabilities/thermostat_mode.json
+++ b/assets/capability/capabilities/thermostat_mode.json
@@ -4,7 +4,7 @@
     "en": "Thermostat mode",
     "nl": "Thermostaatmodus",
     "de": "Thermostat-Modus",
-    "fr": "Mode thermostat",
+    "fr": "Mode du thermostat",
     "it": "Modalità termostato",
     "sv": "Termostatläge",
     "no": "Termostatmodus",


### PR DESCRIPTION
Picks the relevant changes from #619 by @OlivierZal:
- fan_speed: "Fan Speed" → "Fan speed" (sentence case)
- thermostat_mode: French title "Mode thermostat" → "Mode du thermostat"

Other translations from the original PR were included in #696 