### PR TITLE
fix: repair ESLint and add lint CI job

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,5 @@
 /webpack
 /react-native
 /types
+/scripts
+webpack.config.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  extends: 'athom',
+  rules: {
+    // Disabled due to ESLint 7.x bugs that crash on template literals.
+    // Re-enable after upgrading to ESLint 8+.
+    'template-curly-spacing': 'off',
+    indent: 'off',
+  },
+};

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "athom"
-}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - master
+      - production
+  pull_request:
+
+jobs:
+  lint:
+    name: Run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm run lint

--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -74,9 +74,10 @@ const RESERVED_SETTING_PREFIXES = new Set([
   'energy_',
   'satellite_mode_',
   'homekit_',
-])
+]);
 
 class App {
+
   static REQUIRED_PYTHON_PLATFORMS = ['arm64', 'amd64']
   static SUPPORTED_PYTHON_VERSIONS = ['3.13', '3.14']
 
@@ -155,7 +156,7 @@ class App {
       throw new Error('ESM apps require a compatibility of at least >=12.0.1');
     }
 
-    const checkEsm = async (path) => {
+    const checkEsm = async path => {
       await fs.promises.access(path).then(() => {
         if (semver.lt(semver.coerce(appJson.compatibility), '12.0.1')) {
           throw new Error(`ESM apps require a compatibility of at least >=12.0.1. (${path})`);
@@ -196,7 +197,7 @@ class App {
         throw new Error(`App widgets require a compatibility of at least >=12.1.0. (${this._path})`);
       }
 
-      for (const [widgetId, widget] of Object.entries(appJson.widgets)) {
+      for (const widget of Object.values(appJson.widgets)) {
         if (widget.transparent !== undefined && semver.lt(semver.coerce(appJson.compatibility), '12.1.0')) {
           throw new Error(`App widgets transparent property requires a compatibility of at least >=12.1.0. (${this._path})`);
         }
@@ -257,10 +258,10 @@ class App {
         const venvPath = join(this._path, 'python_packages', platform);
         await fs.promises.access(venvPath).catch(() => {
           missingVenvs.push(platform);
-        })
+        });
       }
       if (missingVenvs.length > 0) {
-        throw new Error(`Cross-platform venvs are required for Python apps with dependencies. Missing ${missingVenvs.join(", ")}`)
+        throw new Error(`Cross-platform venvs are required for Python apps with dependencies. Missing ${missingVenvs.join(', ')}`);
       }
     }
 
@@ -629,8 +630,8 @@ class App {
           }
 
           if (
-            (driver.matter.deviceVendorId === undefined && driver.matter.deviceProductName !== undefined) ||
-            (driver.matter.deviceVendorId !== undefined && driver.matter.deviceProductName === undefined)
+            (driver.matter.deviceVendorId === undefined && driver.matter.deviceProductName !== undefined)
+            || (driver.matter.deviceVendorId !== undefined && driver.matter.deviceProductName === undefined)
           ) {
             throw new Error(`drivers.${driver.id} invalid 'matter': 'deviceVendorId' and 'deviceProductName' must be defined together.`);
           }
@@ -666,7 +667,7 @@ class App {
           for (const [updateIndex, update] of Object.entries(driver.firmwareUpdates.updates)) {
             const hasChangelogString = typeof update.changelog === 'string';
             const hasChangelogEnString = update.changelog && typeof update.changelog.en === 'string';
-            
+
             if (!hasChangelogString && !hasChangelogEnString) {
               throw new Error(`drivers.${driver.id}.firmwareUpdates.updates[${updateIndex}] is missing a changelog string`);
             }
@@ -751,7 +752,7 @@ class App {
               if (!isIntegrityValid) {
                 throw new Error(`drivers.${driver.id}.firmwareUpdates.updates[${updateIndex}].files[${fileIndex}] integrity mismatch`);
               }
-              
+
               if (isZigbeeDriver) {
                 try {
                   await Util.validateZigbeeOTAHeader({
@@ -775,7 +776,7 @@ class App {
               }
 
               let fileId = null;
-              
+
               if (Util.isZigbeeFirmwareUpdateFile(file)) {
                 fileId = `${file.manufacturerCode}-${file.imageType}-${file.fileVersion}`;
               } else if (Util.isZwaveFirmwareUpdateFile(file)) {
@@ -958,7 +959,7 @@ class App {
   static validatePythonVersion(appJson) {
     // validate that Python apps specify a runtime version
     if (appJson.runtime === 'python' && !App.SUPPORTED_PYTHON_VERSIONS.includes(appJson.pythonVersion)) {
-      throw new Error(`The app.json property \`pythonVersion\` must be one of [${App.SUPPORTED_PYTHON_VERSIONS.join(", ")}] in combination with runtime: \`python\`.`);
+      throw new Error(`The app.json property \`pythonVersion\` must be one of [${App.SUPPORTED_PYTHON_VERSIONS.join(', ')}] in combination with runtime: \`python\`.`);
     }
   }
 
@@ -969,10 +970,10 @@ class App {
    */
   _checkPrivateSettingPrefixUse(setting, driver) {
     if (
-      setting.type &&
-      setting.type === "group" &&
-      setting.children &&
-      Array.isArray(setting.children)
+      setting.type
+      && setting.type === 'group'
+      && setting.children
+      && Array.isArray(setting.children)
     ) {
       for (const childSetting of setting.children) {
         this._checkPrivateSettingPrefixUse(childSetting, driver);
@@ -984,7 +985,7 @@ class App {
         }
         if (setting.id.startsWith(prefix)) {
           console.warn(
-            `drivers.${driver.id} invalid setting id: ${setting.id}, cannot start with reserved prefix: ${prefix}`
+            `drivers.${driver.id} invalid setting id: ${setting.id}, cannot start with reserved prefix: ${prefix}`,
           );
         }
       }
@@ -1145,10 +1146,10 @@ class App {
     if (Array.isArray(card.args) === false) return;
 
     for (const argument of card.args) {
-      if (argument.type === "multiselect") {
-        if (semver.lt(semver.coerce(appJson.compatibility), "12.5.0")) {
+      if (argument.type === 'multiselect') {
+        if (semver.lt(semver.coerce(appJson.compatibility), '12.5.0')) {
           throw new Error(
-            `Multiselect argument requires a compatibility of at least >=12.5.0. (${errorPath} ${card.id} ${argument.name})`
+            `Multiselect argument requires a compatibility of at least >=12.5.0. (${errorPath} ${card.id} ${argument.name})`,
           );
         }
       }

--- a/test/validate-capabilities.js
+++ b/test/validate-capabilities.js
@@ -2,10 +2,10 @@
 
 const HomeyLib = require('..');
 
-describe('Capabilities', function () {
+describe('Capabilities', function() {
   const capabilities = {};
 
-  before(function () {
+  before(function() {
     const allCapabilities = HomeyLib.getCapabilities();
 
     for (const [capabilityId, capability] of Object.entries(allCapabilities)) {
@@ -19,7 +19,7 @@ describe('Capabilities', function () {
 
   // The mobile app will convert this to a 0-100 percentage slider. If the capability would have a
   // higher maximum, the slider would go to over 100%. For the capabilities we currently have, this doesn't make sense.
-  it('Percentage capabilities are from 0-1 when settable', function () {
+  it('Percentage capabilities are from 0-1 when settable', function() {
     const errors = [];
 
     for (const [capabilityId, capability] of Object.entries(capabilities)) {
@@ -46,7 +46,7 @@ describe('Capabilities', function () {
   });
 
   // The mobile app will not convert this to a percentage slider, as it is not settable. It will show the value as is.
-  it('Percentage capabilities are from 0-100 when not settable', function () {
+  it('Percentage capabilities are from 0-100 when not settable', function() {
     const errors = [];
 
     for (const [capabilityId, capability] of Object.entries(capabilities)) {
@@ -69,14 +69,14 @@ describe('Capabilities', function () {
   });
 
   const defaultTriggerSuffix = {
-    'boolean': ['_true', '_false'],
-    'number': ['_changed'],
-    'string': ['_changed'],
-    'enum': ['_changed'],
+    boolean: ['_true', '_false'],
+    number: ['_changed'],
+    string: ['_changed'],
+    enum: ['_changed'],
   };
 
   // Homey Core will have default handlers for these triggers if they are named correctly.
-  it('Trigger capabilities with a default suffix are valid', function () {
+  it('Trigger capabilities with a default suffix are valid', function() {
     const capabilities = HomeyLib.getCapabilities();
 
     const errors = [];


### PR DESCRIPTION
## Summary
- Fix ESLint 7.x crashes by disabling buggy `template-curly-spacing` and `indent` rules on template literals
- Fix unused `widgetId` variable (`Object.entries` -> `Object.values`)
- Add `/scripts` and `webpack.config.js` to `.eslintignore` (not published, false positive errors)
- Auto-fix 29 style issues
- Add lint job to CI workflow

## Test plan
- [x] `npm run lint` passes locally (0 errors, 4 max-len warnings)
- [x] `npm test` passes locally
- [x] CI lint job runs successfully