### PR TITLE
Add uiState capability schema field

### DIFF
--- a/assets/capability/schema.d.ts
+++ b/assets/capability/schema.d.ts
@@ -32,6 +32,7 @@ export type Capability = {
   uiComponent?:
     | ("thermostat" | "media" | "toggle" | "slider" | "ternary" | "button" | "color" | "picker" | "sensor" | "battery")
     | null;
+  uiState?: boolean;
   [k: string]: unknown;
 } & (
     | {

--- a/assets/capability/schema.json
+++ b/assets/capability/schema.json
@@ -145,6 +145,9 @@
           "type": "null"
         }
       ]
+    },
+    "uiState": {
+      "type": "boolean"
     }
   },
   "_comment": "Require `values` array when `type` is `enum`",


### PR DESCRIPTION
Adds `uiState` as an optional boolean property to the capability JSON schema and regenerates the derived capability schema TypeScript definition.

Validation performed:
- `npm run capability-schema:generate`
- `npm run schema:copy`
- Focused `Capability.validate()` check for boolean, omitted, and invalid string `uiState` values