### PR TITLE
feat: increase meter_power and meter_gas decimals to 3

### DIFF
--- a/assets/capability/capabilities/meter_gas.json
+++ b/assets/capability/capabilities/meter_gas.json
@@ -16,7 +16,7 @@
     "ar": "عداد الغاز"
   },
   "min": 0,
-  "decimals": 2,
+  "decimals": 3,
   "chartType": "spline",
   "units": {
     "en": "m³",

--- a/assets/capability/capabilities/meter_power.json
+++ b/assets/capability/capabilities/meter_power.json
@@ -15,7 +15,7 @@
     "ko": "전력량",
     "ar": "الطاقة"
   },
-  "decimals": 2,
+  "decimals": 3,
   "units": {
     "en": "kWh",
     "ru": "кВтч",


### PR DESCRIPTION
Bumps the default `decimals` of `meter_power` and `meter_gas` from 2 to 3.

kWh and m³ are coarse units, so 2 decimals throws away precision the sources actually provide: DSMR/P1 reports both with 3 decimals, Matter reports energy in mWh, and Zigbee metering commonly uses a divisor of 1000. `meter_water` is already 3, which made m³ for gas inconsistent with m³ for water. Above 3 is float noise.

Notable for already installed devices, `decimals` is read at runtime so there is no migration:

- Stored values keep their 2 decimals until the next update from the device. The Insights log `decimals` is updated in place and only affects rendering, history stays intact.
- Apps that set `capabilitiesOptions.decimals` themselves (P1 apps already use 3) are unaffected, device options win over the capability default.
- Capability changes get more frequent, because the dedupe on an unchanged value catches less. That means more `meter_power_changed` and threshold Flow triggers for users. Insights volume is unaffected, number entries only overwrite the last value and are sampled on time.
- One-off: rounding at 2 decimals is half-up, so a stored value can sit just above the real meter reading. The first 3-decimal update can then be lower, which reads as a meter reset for one report period and self-corrects after that (under 5 Wh / 5 L).

Homey OS needs athombv/node-homey-os#694 for the Energy Dongle to follow this bump correctly.