### PR TITLE
Validate uiState compatibility

### DIFF
--- a/lib/App/index.js
+++ b/lib/App/index.js
@@ -246,6 +246,10 @@ class App {
         if (capability.titleShort !== undefined && semver.lt(appCompatibilityMinVersion, '13.2.1')) {
           throw new Error(`capabilities.${capabilityId}.titleShort requires a compatibility of at least >=13.2.1`);
         }
+
+        if (capability.uiState !== undefined && semver.lt(appCompatibilityMinVersion, '13.5.0')) {
+          throw new Error(`capabilities.${capabilityId}.uiState requires a compatibility of at least >=13.5.0`);
+        }
       }
     }
 
@@ -402,6 +406,10 @@ class App {
 
             if (capabilityOptions.titleShort !== undefined && semver.lt(appCompatibilityMinVersion, '13.2.1')) {
               throw new Error(`drivers.${driver.id}.capabilitiesOptions.${capabilityId}.titleShort requires a compatibility of at least >=13.2.1`);
+            }
+
+            if (capabilityOptions.uiState !== undefined && semver.lt(appCompatibilityMinVersion, '13.5.0')) {
+              throw new Error(`drivers.${driver.id}.capabilitiesOptions.${capabilityId}.uiState requires a compatibility of at least >=13.5.0`);
             }
 
             // Validate target_power_mode values - require homey, at least one non-homey, no reserved prefixes

--- a/test/validate-driver-manifest.js
+++ b/test/validate-driver-manifest.js
@@ -183,6 +183,84 @@ describe('HomeyLib.App#validate() driver manifest', function() {
     });
   });
 
+  it('`capabilities` uiState requires compatibility >=13.5.0', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      compatibility: '>=13.4.0',
+      drivers: [{
+        ...baseDriverManifest,
+        capabilities: ['test'],
+      }],
+      capabilities: {
+        test: {
+          type: 'boolean',
+          title: 'Test capability',
+          getable: true,
+          setable: true,
+          uiState: false,
+        },
+      },
+    });
+
+    await assertValidates(app, {
+      debug: /capabilities\.test\.uiState requires a compatibility of at least >=13\.5\.0/i,
+      publish: /capabilities\.test\.uiState requires a compatibility of at least >=13\.5\.0/i,
+      verified: /capabilities\.test\.uiState requires a compatibility of at least >=13\.5\.0/i,
+    });
+  });
+
+  it('`capabilitiesOptions` uiState requires compatibility >=13.5.0', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      compatibility: '>=13.4.0',
+      drivers: [{
+        ...baseDriverManifest,
+        capabilitiesOptions: {
+          onoff: {
+            uiState: false,
+          },
+        },
+      }],
+    });
+
+    await assertValidates(app, {
+      debug: /drivers\.test\.capabilitiesOptions\.onoff\.uiState requires a compatibility of at least >=13\.5\.0/i,
+      publish: /drivers\.test\.capabilitiesOptions\.onoff\.uiState requires a compatibility of at least >=13\.5\.0/i,
+      verified: /drivers\.test\.capabilitiesOptions\.onoff\.uiState requires a compatibility of at least >=13\.5\.0/i,
+    });
+  });
+
+  it('uiState supports compatibility >=13.5.0', async function() {
+    const app = mockApp({
+      ...baseAppManifest,
+      compatibility: '>=13.5.0',
+      drivers: [{
+        ...baseDriverManifest,
+        capabilities: ['test'],
+        capabilitiesOptions: {
+          test: {
+            uiState: false,
+          },
+        },
+      }],
+      capabilities: {
+        test: {
+          type: 'boolean',
+          title: 'Test capability',
+          getable: true,
+          setable: true,
+          uiState: false,
+        },
+      },
+    });
+
+    await assertValidates(app, {
+      debug: true,
+      publish: true,
+      verified: true,
+    });
+  });
+
   it('`capabilitiesOptions` entries need to be objects', async function() {
     const app = mockApp({
       ...baseAppManifest,


### PR DESCRIPTION
## Summary

- require app compatibility `>=13.5.0` when `uiState` is used in a custom capability definition
- require app compatibility `>=13.5.0` when `uiState` is used in driver `capabilitiesOptions`
- cover rejection below the minimum and acceptance at the minimum version

## Validation

- `npx mocha test/validate-driver-manifest.js`
- `npm test`
- `npm run lint`